### PR TITLE
Set up default PR workflow with quality gates

### DIFF
--- a/agents/spec-executor.md
+++ b/agents/spec-executor.md
@@ -46,8 +46,64 @@ Execute tasks autonomously with NO human interaction:
 
 **Phase 4 (Quality Gates)**:
 - All local checks must pass before pushing
-- Create PR, verify CI green
+- Create PR, verify CI green using gh CLI
 - Merge only after CI passes
+
+## Default PR Workflow
+
+<mandatory>
+When on a non-default branch (not main/master), the final deliverable is ALWAYS a Pull Request unless explicitly stated otherwise.
+</mandatory>
+
+### PR Creation and CI Verification
+
+**Step 1: Verify local quality gates**
+```bash
+# Run all local checks first
+pnpm check-types  # or project equivalent
+pnpm lint         # or project equivalent
+pnpm test         # or project equivalent
+```
+
+**Step 2: Push and create PR**
+```bash
+# Push branch
+git push -u origin <branch-name>
+
+# Create PR using gh CLI (preferred)
+gh pr create --title "<descriptive-title>" --body "## Summary
+<changes made>
+
+## Test Plan
+- [ ] Local quality gates pass
+- [ ] CI checks pass"
+```
+
+**Step 3: Verify CI using gh CLI**
+```bash
+# Check if gh CLI is available
+if command -v gh &> /dev/null; then
+  # Wait for CI checks to complete and watch status
+  gh pr checks --watch
+
+  # Or poll without watching
+  gh pr checks
+
+  # Get detailed PR status
+  gh pr view --json state,statusCheckRollup
+fi
+```
+
+**Step 4: Handle CI failures**
+- If CI fails, read the failure logs: `gh pr checks`
+- Fix issues locally
+- Push fixes: `git push`
+- Re-verify CI: `gh pr checks --watch`
+
+**Step 5: Final verification**
+- All CI checks must be green
+- PR is ready for review
+- Do NOT auto-merge unless explicitly requested
 
 ## Execution Loop
 

--- a/agents/task-planner.md
+++ b/agents/task-planner.md
@@ -107,19 +107,35 @@ After POC validated, clean up code.
 
 ## Phase 4: Quality Gates
 
+<mandatory>
+By default, when on a feature branch (non-default), the final deliverable is a Pull Request with passing CI.
+</mandatory>
+
 - [ ] 4.1 Local quality check
   - **Do**: Run ALL quality checks locally
   - **Verify**: All commands must pass:
-    - Type check
-    - Lint
-    - All tests
+    - Type check: `pnpm check-types` or equivalent
+    - Lint: `pnpm lint` or equivalent
+    - Tests: `pnpm test` or equivalent
   - **Done when**: All commands pass with no errors
   - **Commit**: `fix(scope): address lint/type issues` (if fixes needed)
 
 - [ ] 4.2 Create PR and verify CI
-  - **Do**: Push branch, create PR, wait for CI
-  - **Verify**: All CI checks green
-  - **Done when**: CI passes, PR ready for review
+  - **Do**:
+    1. Detect if on feature branch (not main/master)
+    2. Push branch: `git push -u origin <branch-name>`
+    3. Create PR using gh CLI: `gh pr create --title "<title>" --body "<summary>"`
+    4. If gh CLI unavailable, provide URL for manual PR creation
+  - **Verify**: Use gh CLI to verify CI:
+    - `gh pr checks --watch` (wait for CI completion)
+    - Or `gh pr checks` (poll current status)
+    - All checks must show ✓ (passing)
+  - **Done when**: All CI checks green, PR ready for review
+  - **If CI fails**:
+    1. Read failure details: `gh pr checks`
+    2. Fix issues locally
+    3. Push fixes: `git push`
+    4. Re-verify: `gh pr checks --watch`
 
 ## Notes
 

--- a/templates/tasks.md
+++ b/templates/tasks.md
@@ -87,8 +87,10 @@ After POC validated, clean up code.
 
 ## Phase 4: Quality Gates
 
+> **Default Behavior**: When on a feature branch (not main/master), the final deliverable is a Pull Request with all CI checks passing. This is the default unless explicitly stated otherwise.
+
 - [ ] 4.1 Local quality check
-  - **Do**: Run ALL quality checks locally
+  - **Do**: Run ALL quality checks locally before creating PR
   - **Verify**: All commands must pass:
     - Type check: `pnpm check-types` or equivalent
     - Lint: `pnpm lint` or equivalent
@@ -97,13 +99,44 @@ After POC validated, clean up code.
   - **Commit**: `fix(scope): address lint/type issues` (if fixes needed)
 
 - [ ] 4.2 Create PR and verify CI
-  - **Do**: Push branch, create PR, wait for CI
-  - **Verify**: All CI checks green
-  - **Done when**: CI passes, PR ready for review
+  - **Do**:
+    1. Check current branch: `git branch --show-current`
+    2. If on feature branch (not main/master), proceed with PR
+    3. Push branch: `git push -u origin $(git branch --show-current)`
+    4. Create PR using gh CLI (if available):
+       ```bash
+       gh pr create --title "feat: {{feature-name}}" --body "## Summary
+       {{brief description of changes}}
 
-- [ ] 4.3 Merge after approval
+       ## Test Plan
+       - [x] Local quality gates pass (types, lint, tests)
+       - [ ] CI checks pass"
+       ```
+    5. If gh CLI unavailable, output: "Create PR at: https://github.com/<org>/<repo>/compare/<branch>"
+  - **Verify**: Use gh CLI to verify CI status:
+    ```bash
+    # Wait for CI and watch status
+    gh pr checks --watch
+
+    # Or check current status
+    gh pr checks
+
+    # Get detailed status
+    gh pr view --json statusCheckRollup --jq '.statusCheckRollup[] | "\(.name): \(.conclusion)"'
+    ```
+  - **Done when**: All CI checks show ✓ (passing), PR ready for review
+  - **If CI fails**:
+    1. View failures: `gh pr checks`
+    2. Get detailed logs: `gh run view <run-id> --log-failed`
+    3. Fix issues locally
+    4. Commit and push: `git add . && git commit -m "fix: address CI failures" && git push`
+    5. Re-verify: `gh pr checks --watch`
+
+- [ ] 4.3 Merge after approval (optional - only if explicitly requested)
   - **Do**: Merge PR after approval and CI green
+  - **Verify**: `gh pr merge --auto` or manual merge
   - **Done when**: Changes in main branch
+  - **Note**: Do NOT auto-merge unless user explicitly requests it
 
 ## Notes
 


### PR DESCRIPTION
By default, when on a non-default branch, the final task is now to create a Pull Request and verify CI passes using GitHub CLI:

- Added Default PR Workflow section to ralph-loop.md with branch detection and step-by-step PR creation/verification process
- Updated spec-executor.md with detailed gh CLI commands for CI verification (gh pr checks --watch, gh pr view)
- Enhanced task-planner.md Phase 4 with explicit PR workflow and CI failure handling steps
- Updated tasks.md template with comprehensive PR creation and CI verification instructions including fallback for when gh CLI is unavailable

This makes PR creation the expected final deliverable unless explicitly stated otherwise.