### PR TITLE
Grant all agents and commands explore access

### DIFF
--- a/plugins/ralph-specum/agents/architect-reviewer.md
+++ b/plugins/ralph-specum/agents/architect-reviewer.md
@@ -2,7 +2,7 @@
 name: architect-reviewer
 description: Expert systems architect for technical design. Masters system design, component architecture, patterns, and technical trade-off analysis.
 model: inherit
-tools: Read, Write, Edit, Bash, Glob, Grep
+tools: [Read, Write, Edit, Bash, Glob, Grep, Task]
 ---
 
 You are a senior systems architect with expertise in designing scalable, maintainable systems. Your focus is architecture decisions, component boundaries, patterns, and technical feasibility.

--- a/plugins/ralph-specum/agents/product-manager.md
+++ b/plugins/ralph-specum/agents/product-manager.md
@@ -2,7 +2,7 @@
 name: product-manager
 description: Expert product manager for requirements gathering. Focuses on user stories, acceptance criteria, business value, and user-centric development.
 model: inherit
-tools: Read, Write, Edit, Glob, Grep, WebSearch
+tools: [Read, Write, Edit, Glob, Grep, WebSearch, Task]
 ---
 
 You are a senior product manager with expertise in translating user goals into structured requirements. Your focus is user empathy, business value framing, and creating testable acceptance criteria.

--- a/plugins/ralph-specum/agents/research-analyst.md
+++ b/plugins/ralph-specum/agents/research-analyst.md
@@ -2,7 +2,7 @@
 name: research-analyst
 description: Expert analyzer and researcher that never assumes. Always verifies through web search, documentation, and codebase exploration before providing findings. Use for initial project research, feasibility analysis, and gathering context before requirements.
 model: inherit
-tools: [Read, Write, Edit, Glob, Grep, WebFetch, WebSearch]
+tools: [Read, Write, Edit, Glob, Grep, WebFetch, WebSearch, Task]
 ---
 
 You are a senior analyzer and researcher with a strict "verify-first, assume-never" methodology. Your core principle: **never guess, always check**.

--- a/plugins/ralph-specum/agents/spec-executor.md
+++ b/plugins/ralph-specum/agents/spec-executor.md
@@ -2,7 +2,7 @@
 name: spec-executor
 description: Autonomous task executor for spec-driven development. Executes a single task from tasks.md, verifies, commits, and signals completion.
 model: inherit
-tools: [Read, Write, Edit, Bash, Glob, Grep]
+tools: [Read, Write, Edit, Bash, Glob, Grep, Task]
 ---
 
 You are an autonomous execution agent that implements ONE task from a spec. You execute the task exactly as specified, verify completion, commit changes, update progress, and signal completion.

--- a/plugins/ralph-specum/agents/task-planner.md
+++ b/plugins/ralph-specum/agents/task-planner.md
@@ -2,7 +2,7 @@
 name: task-planner
 description: Expert task planner for breaking design into executable tasks. Masters POC-first workflow, task sequencing, and quality gates.
 model: inherit
-tools: Read, Write, Edit, Glob, Grep
+tools: [Read, Write, Edit, Glob, Grep, Task]
 ---
 
 You are a task planning specialist who breaks designs into executable implementation steps. Your focus is POC-first workflow, clear task definitions, and quality gates.

--- a/plugins/ralph-specum/commands/cancel.md
+++ b/plugins/ralph-specum/commands/cancel.md
@@ -1,7 +1,7 @@
 ---
 description: Cancel active execution loop and cleanup state
 argument-hint: [spec-name]
-allowed-tools: [Read, Bash]
+allowed-tools: [Read, Bash, Task]
 ---
 
 # Cancel Execution

--- a/plugins/ralph-specum/commands/status.md
+++ b/plugins/ralph-specum/commands/status.md
@@ -1,7 +1,7 @@
 ---
 description: Show all specs and their current status
 argument-hint:
-allowed-tools: [Read, Bash, Glob]
+allowed-tools: [Read, Bash, Glob, Task]
 ---
 
 # Spec Status

--- a/plugins/ralph-specum/commands/switch.md
+++ b/plugins/ralph-specum/commands/switch.md
@@ -1,7 +1,7 @@
 ---
 description: Switch active spec
 argument-hint: <spec-name>
-allowed-tools: [Read, Write, Bash, Glob]
+allowed-tools: [Read, Write, Bash, Glob, Task]
 ---
 
 # Switch Active Spec


### PR DESCRIPTION
Enable all sub-agents and commands to invoke the native Claude Code Explore sub-agent via the Task tool for codebase exploration.

Agents updated:
- research-analyst
- product-manager
- architect-reviewer
- task-planner
- spec-executor

Commands updated:
- status
- switch
- cancel