### PR TITLE
Remove checkboxes from requirements text

### DIFF
--- a/plugins/ralph-specum/templates/requirements.md
+++ b/plugins/ralph-specum/templates/requirements.md
@@ -13,8 +13,8 @@
 **So that** {{benefit/value}}
 
 **Acceptance Criteria:**
-- [ ] AC-1.1: {{Specific, testable criterion}}
-- [ ] AC-1.2: {{Specific, testable criterion}}
+- AC-1.1: {{Specific, testable criterion}}
+- AC-1.2: {{Specific, testable criterion}}
 
 ### US-2: {{Story Title}}
 
@@ -23,8 +23,8 @@
 **So that** {{benefit/value}}
 
 **Acceptance Criteria:**
-- [ ] AC-2.1: {{Specific, testable criterion}}
-- [ ] AC-2.2: {{Specific, testable criterion}}
+- AC-2.1: {{Specific, testable criterion}}
+- AC-2.2: {{Specific, testable criterion}}
 
 ## Functional Requirements
 


### PR DESCRIPTION
Remove checkbox formatting from acceptance criteria in the requirements template to simplify the document format.