### PR TITLE
Add quality gate checks to task creation

### DIFF
--- a/plugins/ralph-specum/agents/task-planner.md
+++ b/plugins/ralph-specum/agents/task-planner.md
@@ -24,6 +24,42 @@ ALL specs MUST follow POC-first workflow:
 4. **Phase 4: Quality Gates** - Lint, types, CI verification
 </mandatory>
 
+## Intermediate Quality Gate Checkpoints
+
+<mandatory>
+Insert quality gate checkpoints throughout the task list to catch issues early:
+
+**Frequency Rules:**
+- After every **2-3 tasks** (depending on task complexity), add a Quality Checkpoint task
+- For **small/simple tasks**: Insert checkpoint after 3 tasks
+- For **medium tasks**: Insert checkpoint after 2-3 tasks
+- For **large/complex tasks**: Insert checkpoint after 2 tasks
+
+**What Quality Checkpoints verify:**
+1. Type checking passes: `pnpm check-types` or equivalent
+2. Lint passes: `pnpm lint` or equivalent
+3. Existing tests pass: `pnpm test` or equivalent (if tests exist)
+4. Code compiles/builds successfully
+
+**Checkpoint Task Format:**
+```markdown
+- [ ] X.Y Quality Checkpoint
+  - **Do**: Run all quality checks to verify recent changes don't break the build
+  - **Verify**: All commands must pass:
+    - Type check: `pnpm check-types` or equivalent
+    - Lint: `pnpm lint` or equivalent
+    - Tests: `pnpm test` (if applicable)
+  - **Done when**: All quality checks pass with no errors
+  - **Commit**: `chore(scope): pass quality checkpoint` (only if fixes were needed)
+```
+
+**Rationale:**
+- Catch type errors, lint issues, and regressions early
+- Prevent accumulation of technical debt
+- Ensure each batch of work maintains code quality
+- Make debugging easier by limiting scope of potential issues
+</mandatory>
+
 ## Tasks Structure
 
 Create tasks.md following this structure:
@@ -53,7 +89,22 @@ Focus: Validate the idea works end-to-end. Skip tests, accept hardcoded values.
   - _Requirements: FR-2_
   - _Design: Component B_
 
-- [ ] 1.3 POC Checkpoint
+- [ ] 1.3 Quality Checkpoint
+  - **Do**: Run all quality checks to verify recent changes don't break the build
+  - **Verify**: All commands must pass:
+    - Type check: `pnpm check-types` or equivalent
+    - Lint: `pnpm lint` or equivalent
+  - **Done when**: All quality checks pass with no errors
+  - **Commit**: `chore(scope): pass quality checkpoint` (only if fixes needed)
+
+- [ ] 1.4 [Continue with more tasks...]
+  - **Do**: [Steps]
+  - **Files**: [Paths]
+  - **Done when**: [Criteria]
+  - **Verify**: [Command]
+  - **Commit**: `feat(scope): [description]`
+
+- [ ] 1.5 POC Checkpoint
   - **Do**: Verify feature works end-to-end
   - **Done when**: Feature can be demonstrated working
   - **Verify**: Manual test of core flow
@@ -78,6 +129,15 @@ After POC validated, clean up code.
   - **Commit**: `refactor(scope): add error handling`
   - _Design: Error Handling_
 
+- [ ] 2.3 Quality Checkpoint
+  - **Do**: Run all quality checks to verify refactoring doesn't break the build
+  - **Verify**: All commands must pass:
+    - Type check: `pnpm check-types` or equivalent
+    - Lint: `pnpm lint` or equivalent
+    - Tests: `pnpm test` (if applicable)
+  - **Done when**: All quality checks pass with no errors
+  - **Commit**: `chore(scope): pass quality checkpoint` (only if fixes needed)
+
 ## Phase 3: Testing
 
 - [ ] 3.1 Unit tests for [component]
@@ -97,7 +157,16 @@ After POC validated, clean up code.
   - **Commit**: `test(scope): add integration tests`
   - _Design: Test Strategy_
 
-- [ ] 3.3 E2E tests (if UI)
+- [ ] 3.3 Quality Checkpoint
+  - **Do**: Run all quality checks to verify tests don't introduce issues
+  - **Verify**: All commands must pass:
+    - Type check: `pnpm check-types` or equivalent
+    - Lint: `pnpm lint` or equivalent
+    - Tests: `pnpm test`
+  - **Done when**: All quality checks pass with no errors
+  - **Commit**: `chore(scope): pass quality checkpoint` (only if fixes needed)
+
+- [ ] 3.4 E2E tests (if UI)
   - **Do**: Create E2E test at [path]
   - **Files**: [test file path]
   - **Done when**: User flow tested
@@ -167,5 +236,6 @@ Before completing tasks:
 - [ ] All tasks reference requirements/design
 - [ ] POC phase focuses on validation, not perfection
 - [ ] Each task has verify step
+- [ ] **Quality checkpoints inserted every 2-3 tasks throughout all phases**
 - [ ] Quality gates are last phase
 - [ ] Tasks are ordered by dependency

--- a/plugins/ralph-specum/templates/tasks.md
+++ b/plugins/ralph-specum/templates/tasks.md
@@ -5,6 +5,8 @@
 Total tasks: {{N}}
 POC-first workflow with 4 phases.
 
+> **Quality Checkpoints**: Intermediate quality gate checks are inserted every 2-3 tasks to catch issues early. For small tasks, insert after 3 tasks. For medium/large tasks, insert after 2 tasks.
+
 ## Phase 1: Make It Work (POC)
 
 Focus: Validate the idea works end-to-end. Skip tests, accept hardcoded values.
@@ -27,7 +29,22 @@ Focus: Validate the idea works end-to-end. Skip tests, accept hardcoded values.
   - _Requirements: FR-2_
   - _Design: Component B_
 
-- [ ] 1.3 POC Checkpoint
+- [ ] 1.3 Quality Checkpoint
+  - **Do**: Run all quality checks to verify recent changes don't break the build
+  - **Verify**: All commands must pass:
+    - Type check: `pnpm check-types` or equivalent
+    - Lint: `pnpm lint` or equivalent
+  - **Done when**: All quality checks pass with no errors
+  - **Commit**: `chore(scope): pass quality checkpoint` (only if fixes needed)
+
+- [ ] 1.4 {{Continue with more tasks...}}
+  - **Do**: {{Steps}}
+  - **Files**: {{Paths}}
+  - **Done when**: {{Criteria}}
+  - **Verify**: {{Command}}
+  - **Commit**: `feat(scope): {{description}}`
+
+- [ ] 1.5 POC Checkpoint
   - **Do**: Verify feature works end-to-end
   - **Done when**: Feature can be demonstrated working
   - **Verify**: Manual test of core flow
@@ -52,7 +69,16 @@ After POC validated, clean up code.
   - **Commit**: `refactor(scope): add error handling`
   - _Design: Error Handling_
 
-- [ ] 2.3 Code cleanup
+- [ ] 2.3 Quality Checkpoint
+  - **Do**: Run all quality checks to verify refactoring doesn't break the build
+  - **Verify**: All commands must pass:
+    - Type check: `pnpm check-types` or equivalent
+    - Lint: `pnpm lint` or equivalent
+    - Tests: `pnpm test` (if applicable)
+  - **Done when**: All quality checks pass with no errors
+  - **Commit**: `chore(scope): pass quality checkpoint` (only if fixes needed)
+
+- [ ] 2.4 Code cleanup
   - **Do**: Remove hardcoded values, add proper types
   - **Done when**: No TODOs or hardcoded values remain
   - **Verify**: Code review checklist passes
@@ -77,7 +103,16 @@ After POC validated, clean up code.
   - **Commit**: `test(scope): add integration tests`
   - _Design: Test Strategy_
 
-- [ ] 3.3 E2E tests (if UI)
+- [ ] 3.3 Quality Checkpoint
+  - **Do**: Run all quality checks to verify tests don't introduce issues
+  - **Verify**: All commands must pass:
+    - Type check: `pnpm check-types` or equivalent
+    - Lint: `pnpm lint` or equivalent
+    - Tests: `pnpm test`
+  - **Done when**: All quality checks pass with no errors
+  - **Commit**: `chore(scope): pass quality checkpoint` (only if fixes needed)
+
+- [ ] 3.4 E2E tests (if UI)
   - **Do**: Create E2E test at {{path}}
   - **Files**: {{test file path}}
   - **Done when**: User flow tested


### PR DESCRIPTION
Insert quality gate checks every 2-3 tasks throughout all phases to:
- Catch type errors, lint issues, and regressions early
- Prevent accumulation of technical debt
- Make debugging easier by limiting scope of potential issues

Frequency rules based on task complexity:
- Small tasks: checkpoint after 3 tasks
- Medium tasks: checkpoint after 2-3 tasks
- Large tasks: checkpoint after 2 tasks

## What

<!-- Brief description of changes -->

## Why

<!-- Why this change is needed -->

## Testing

<!-- How you tested it -->

## Checklist

- [ ] I tested locally with `claude --plugin-dir`
- [ ] I updated documentation if needed
- [ ] My commits have clear messages
