### PR TITLE
Fix stop handler task completion verification

### DIFF
--- a/plugins/ralph-specum/agents/spec-executor.md
+++ b/plugins/ralph-specum/agents/spec-executor.md
@@ -114,7 +114,13 @@ If task fails:
 3. Retry verification
 4. If still blocked after attempts, describe issue
 
-Do NOT output TASK_COMPLETE if verification fails.
+Do NOT output TASK_COMPLETE if:
+- Verification failed
+- Implementation is partial
+- You encountered unresolved errors
+- You skipped required steps
+
+Lying about completion wastes iterations and breaks the spec workflow.
 
 ## Output Format
 
@@ -134,3 +140,15 @@ Task X.Y: [task name] FAILED
 - Attempted fix: [what was tried]
 - Status: Blocked, needs manual intervention
 ```
+
+## Completion Integrity
+
+<mandatory>
+NEVER output TASK_COMPLETE unless the task is TRULY complete:
+- Verification command passed
+- All "Done when" criteria met
+- Changes committed successfully
+
+Do NOT lie to exit the loop. If blocked, describe the issue honestly.
+The stop-hook verifies TASK_COMPLETE in transcript. False completion will be caught and retried.
+</mandatory>

--- a/plugins/ralph-specum/hooks/scripts/stop-handler.sh
+++ b/plugins/ralph-specum/hooks/scripts/stop-handler.sh
@@ -2,6 +2,8 @@
 # Ralph Specum Stop Hook Handler
 # Handles task-by-task execution loop with fresh context per task
 
+set -euo pipefail
+
 # Read input from stdin (Claude Code hook input)
 INPUT=$(cat)
 
@@ -41,6 +43,19 @@ GLOBAL_ITER=$(echo "$STATE" | jq -r '.globalIteration' 2>/dev/null) || exit 0
 MAX_GLOBAL_ITER=$(echo "$STATE" | jq -r '.maxGlobalIterations' 2>/dev/null) || exit 0
 SPEC_PATH=$(echo "$STATE" | jq -r '.basePath' 2>/dev/null) || exit 0
 
+# Extract last assistant message from transcript for completion verification
+if [[ -z "$TRANSCRIPT_PATH" ]] || [[ ! -f "$TRANSCRIPT_PATH" ]]; then
+    LAST_OUTPUT=""
+else
+    # Extract last assistant message text content
+    LAST_OUTPUT=$(grep '"role":"assistant"' "$TRANSCRIPT_PATH" | tail -1 | jq -r '
+        .message.content |
+        map(select(.type == "text")) |
+        map(.text) |
+        join("\n")
+    ' 2>/dev/null || echo "")
+fi
+
 # Validate required fields parsed correctly
 if [[ -z "$PHASE" || "$PHASE" == "null" ]]; then
     exit 0  # Invalid state, allow stop
@@ -48,7 +63,9 @@ fi
 
 # Check global iteration limit (safety cap)
 if [[ $GLOBAL_ITER -ge $MAX_GLOBAL_ITER ]]; then
-    echo "{\"decision\": \"block\", \"reason\": \"Max global iterations ($MAX_GLOBAL_ITER) reached. Run /ralph-specum:cancel to cleanup and review progress.\"}"
+    jq -n \
+        --arg reason "Max global iterations ($MAX_GLOBAL_ITER) reached. Run /ralph-specum:cancel to cleanup and review progress." \
+        '{"decision": "block", "reason": $reason}'
     exit 0
 fi
 
@@ -59,7 +76,9 @@ fi
 
 # Check if task failed too many times
 if [[ $TASK_ITER -ge $MAX_TASK_ITER ]]; then
-    echo "{\"decision\": \"block\", \"reason\": \"Task $TASK_INDEX failed after $MAX_TASK_ITER attempts. Fix the issue manually, then run /ralph-specum:implement to resume from task $TASK_INDEX.\"}"
+    jq -n \
+        --arg reason "Task $TASK_INDEX failed after $MAX_TASK_ITER attempts. Fix the issue manually, then run /ralph-specum:implement to resume from task $TASK_INDEX." \
+        '{"decision": "block", "reason": $reason}'
     exit 0
 fi
 
@@ -68,6 +87,31 @@ if [[ $TASK_INDEX -ge $TOTAL_TASKS ]]; then
     # All tasks complete! Cleanup state file, keep progress
     rm "$STATE_FILE"
     exit 0  # Allow stop - execution complete
+fi
+
+# Verify TASK_COMPLETE signal before advancing to next task
+if ! echo "$LAST_OUTPUT" | grep -q "TASK_COMPLETE"; then
+    # Task did not complete successfully - retry same task
+    NEW_TASK_ITER=$((TASK_ITER + 1))
+
+    # Update state for retry (same task, incremented iteration)
+    TEMP_STATE=$(mktemp)
+    if echo "$STATE" | jq "
+        .taskIteration = $NEW_TASK_ITER |
+        .globalIteration = $((GLOBAL_ITER + 1))
+    " > "$TEMP_STATE" 2>/dev/null && [[ -s "$TEMP_STATE" ]]; then
+        mv "$TEMP_STATE" "$STATE_FILE"
+    else
+        rm -f "$TEMP_STATE"
+        exit 0  # Failed to update state, allow stop
+    fi
+
+    REASON="Task $TASK_INDEX did not complete. Retry attempt $NEW_TASK_ITER. Read $SPEC_PATH/.progress.md for context and continue task $TASK_INDEX from $SPEC_PATH/tasks.md."
+    jq -n \
+        --arg reason "$REASON" \
+        --arg msg "Task $TASK_INDEX incomplete. Retrying ($NEW_TASK_ITER/$MAX_TASK_ITER)." \
+        '{"decision": "block", "reason": $reason, "systemMessage": $msg}'
+    exit 0
 fi
 
 # Continue to next task with fresh context
@@ -87,8 +131,10 @@ else
     exit 0  # Failed to update state, allow stop
 fi
 
-# Return block decision with continue prompt
-# The reason becomes the next user input, giving fresh context
+# Return block decision with continue prompt using safe jq output
 REASON="Continue execution for spec '$CURRENT_SPEC'. Read $SPEC_PATH/.progress.md for context and $SPEC_PATH/tasks.md for task $NEW_TASK_INDEX."
 
-echo "{\"decision\": \"block\", \"reason\": \"$REASON\", \"systemMessage\": \"Task $TASK_INDEX complete. Continuing to task $NEW_TASK_INDEX of $TOTAL_TASKS.\"}"
+jq -n \
+    --arg reason "$REASON" \
+    --arg msg "Task $TASK_INDEX complete. Continuing to task $NEW_TASK_INDEX of $TOTAL_TASKS." \
+    '{"decision": "block", "reason": $reason, "systemMessage": $msg}'


### PR DESCRIPTION
- Add strict bash mode (set -euo pipefail) to stop-handler.sh
- Extract and verify TASK_COMPLETE from transcript before advancing
- Retry same task with incremented taskIteration if incomplete
- Use jq for safe JSON output instead of string interpolation
- Add Completion Integrity section to spec-executor.md
- Strengthen guidance about never lying about task completion

This ensures failed tasks get retried rather than blindly skipped.

## What

<!-- Brief description of changes -->

## Why

<!-- Why this change is needed -->

## Testing

<!-- How you tested it -->

## Checklist

- [ ] I tested locally with `claude --plugin-dir`
- [ ] I updated documentation if needed
- [ ] My commits have clear messages
