### PR TITLE
Require subagents to append learnings to progress

### DIFF
--- a/plugins/ralph-specum/agents/architect-reviewer.md
+++ b/plugins/ralph-specum/agents/architect-reviewer.md
@@ -13,6 +13,27 @@ When invoked:
 3. Design architecture that satisfies requirements
 4. Document technical decisions and trade-offs
 5. Define interfaces and data flow
+6. Append learnings to .progress.md
+
+## Append Learnings
+
+<mandatory>
+After completing design, append any significant discoveries to `./specs/<spec>/.progress.md`:
+
+```markdown
+## Learnings
+- Previous learnings...
+- [NEW] Architecture insight from design  <-- APPEND NEW LEARNINGS
+- [NEW] Pattern discovered in codebase
+```
+
+What to append:
+- Architectural constraints discovered during design
+- Trade-offs made and their rationale
+- Existing patterns that must be followed
+- Technical debt that may affect implementation
+- Integration points that are complex or risky
+</mandatory>
 
 ## Design Structure
 

--- a/plugins/ralph-specum/agents/plan-synthesizer.md
+++ b/plugins/ralph-specum/agents/plan-synthesizer.md
@@ -13,7 +13,28 @@ You are a rapid spec synthesizer that converts a user plan/goal into complete sp
 2. Explore codebase for existing patterns (brief, targeted)
 3. Generate all four artifacts in sequence
 4. Mark each with `generated: auto` frontmatter
-5. Return task count for execution start
+5. Append learnings to .progress.md
+6. Return task count for execution start
+
+## Append Learnings
+
+<mandatory>
+After generating artifacts, append any significant discoveries to `./specs/<spec>/.progress.md`:
+
+```markdown
+## Learnings
+- Previous learnings...
+- [NEW] Synthesis insight from quick mode  <-- APPEND NEW LEARNINGS
+- [NEW] Pattern found during exploration
+```
+
+What to append:
+- Codebase patterns discovered during exploration
+- Feasibility concerns identified
+- Scope decisions made during synthesis
+- Assumptions made due to quick mode constraints
+- Areas that may need manual review
+</mandatory>
 
 ## Constraints
 

--- a/plugins/ralph-specum/agents/product-manager.md
+++ b/plugins/ralph-specum/agents/product-manager.md
@@ -13,6 +13,27 @@ When invoked:
 3. Create comprehensive requirements with user stories
 4. Define clear acceptance criteria that are testable
 5. Identify out-of-scope items and dependencies
+6. Append learnings to .progress.md
+
+## Append Learnings
+
+<mandatory>
+After completing requirements, append any significant discoveries to `./specs/<spec>/.progress.md`:
+
+```markdown
+## Learnings
+- Previous learnings...
+- [NEW] Requirement insight from analysis  <-- APPEND NEW LEARNINGS
+- [NEW] User story pattern discovered
+```
+
+What to append:
+- Ambiguities discovered during requirements analysis
+- Scope decisions that may affect implementation
+- Business logic complexities uncovered
+- Dependencies between user stories
+- Any assumptions made that should be validated
+</mandatory>
 
 ## Requirements Structure
 

--- a/plugins/ralph-specum/agents/research-analyst.md
+++ b/plugins/ralph-specum/agents/research-analyst.md
@@ -24,6 +24,27 @@ You are a senior analyzer and researcher with a strict "verify-first, assume-nev
 3. **Research internally** - Read existing codebase, architecture, related implementations
 4. **Cross-reference** - Verify findings across multiple sources
 5. **Synthesize output** - Provide well-sourced research.md or ask clarifying questions
+6. **Append learnings** - Record discoveries in .progress.md
+
+## Append Learnings
+
+<mandatory>
+After completing research, append any significant discoveries to `./specs/<spec>/.progress.md`:
+
+```markdown
+## Learnings
+- Previous learnings...
+- [NEW] Discovery about X from research  <-- APPEND NEW LEARNINGS
+- [NEW] Found pattern Y in codebase
+```
+
+What to append:
+- Unexpected technical constraints discovered
+- Useful patterns found in codebase
+- External best practices that differ from current implementation
+- Dependencies or limitations that affect future tasks
+- Any "gotchas" future agents should know about
+</mandatory>
 
 ## Research Methodology
 

--- a/plugins/ralph-specum/agents/task-planner.md
+++ b/plugins/ralph-specum/agents/task-planner.md
@@ -13,6 +13,27 @@ When invoked:
 3. Create tasks that are autonomous-execution ready
 4. Include verification steps and commit messages
 5. Reference requirements/design in each task
+6. Append learnings to .progress.md
+
+## Append Learnings
+
+<mandatory>
+After completing task planning, append any significant discoveries to `./specs/<spec>/.progress.md`:
+
+```markdown
+## Learnings
+- Previous learnings...
+- [NEW] Task planning insight  <-- APPEND NEW LEARNINGS
+- [NEW] Dependency discovered between components
+```
+
+What to append:
+- Task dependencies that affect execution order
+- Risk areas identified during planning
+- Verification commands that may need adjustment
+- Shortcuts planned for POC phase
+- Complex areas that may need extra attention
+</mandatory>
 
 ## POC-First Workflow
 


### PR DESCRIPTION
Add mandatory "Append Learnings" section to all subagent definitions:
- research-analyst: discoveries from research phase
- product-manager: requirement insights and assumptions
- architect-reviewer: architecture constraints and trade-offs
- task-planner: task dependencies and risk areas
- plan-synthesizer: codebase patterns from quick mode

This ensures knowledge is captured and shared across all spec phases, not just during task execution.

## What

<!-- Brief description of changes -->

## Why

<!-- Why this change is needed -->

## Testing

<!-- How you tested it -->

## Checklist

- [ ] I tested locally with `claude --plugin-dir`
- [ ] I updated documentation if needed
- [ ] My commits have clear messages
