### PR TITLE
Add parallel task execution support

### DIFF
--- a/plugins/ralph-specum/agents/task-planner.md
+++ b/plugins/ralph-specum/agents/task-planner.md
@@ -24,6 +24,41 @@ ALL specs MUST follow POC-first workflow:
 4. **Phase 4: Quality Gates** - Lint, types, CI verification
 </mandatory>
 
+## Parallel Task Execution
+
+<mandatory>
+Mark independent tasks with `[P]` to enable parallel execution:
+
+**When to use parallel tasks:**
+- Tasks that don't depend on each other's output
+- Tasks that modify different files (no overlap in **Files** sections)
+- Tasks that can be verified independently
+- Examples: creating separate test files, implementing independent components, writing unrelated documentation
+
+**Format:**
+```markdown
+- [P] X.1 First parallel task
+  - **Do**: ...
+  - **Files**: path/to/file1.ts
+  - ...
+
+- [P] X.2 Second parallel task (runs simultaneously)
+  - **Do**: ...
+  - **Files**: path/to/file2.ts
+  - ...
+
+- [ ] X.3 Sequential task (waits for parallel tasks to complete)
+  - **Do**: ...
+```
+
+**Rules:**
+- Consecutive `[P]` tasks form a parallel group
+- A non-`[P]` task (including `[ ]`) breaks the parallel group
+- Quality Checkpoints MUST be `[ ]` (sequential) to verify all parallel work
+- Never mark tasks as `[P]` if they modify the same files
+- Limit parallel groups to 3-4 tasks max for manageability
+</mandatory>
+
 ## Intermediate Quality Gate Checkpoints
 
 <mandatory>
@@ -140,20 +175,20 @@ After POC validated, clean up code.
 
 ## Phase 3: Testing
 
-- [ ] 3.1 Unit tests for [component]
+- [P] 3.1 Unit tests for [component]
   - **Do**: Create test file at [path]
   - **Files**: [test file path]
   - **Done when**: Tests cover main functionality
-  - **Verify**: `pnpm test` or test command passes
+  - **Verify**: `pnpm test -- [test file]` passes
   - **Commit**: `test(scope): add unit tests for [component]`
   - _Requirements: AC-1.1, AC-1.2_
   - _Design: Test Strategy_
 
-- [ ] 3.2 Integration tests
+- [P] 3.2 Integration tests
   - **Do**: Create integration test at [path]
   - **Files**: [test file path]
   - **Done when**: Integration points tested
-  - **Verify**: Test command passes
+  - **Verify**: `pnpm test -- [test file]` passes
   - **Commit**: `test(scope): add integration tests`
   - _Design: Test Strategy_
 
@@ -239,3 +274,5 @@ Before completing tasks:
 - [ ] **Quality checkpoints inserted every 2-3 tasks throughout all phases**
 - [ ] Quality gates are last phase
 - [ ] Tasks are ordered by dependency
+- [ ] **Independent tasks marked with `[P]` for parallel execution** (especially in Testing phase)
+- [ ] Parallel tasks don't modify the same files

--- a/plugins/ralph-specum/templates/tasks.md
+++ b/plugins/ralph-specum/templates/tasks.md
@@ -7,6 +7,8 @@ POC-first workflow with 4 phases.
 
 > **Quality Checkpoints**: Intermediate quality gate checks are inserted every 2-3 tasks to catch issues early. For small tasks, insert after 3 tasks. For medium/large tasks, insert after 2 tasks.
 
+> **Parallel Tasks**: Tasks marked with `[P]` can be executed in parallel. Consecutive `[P]` tasks in the same group will be launched simultaneously. Use this for independent tasks that don't depend on each other (e.g., creating separate test files, implementing unrelated components).
+
 ## Phase 1: Make It Work (POC)
 
 Focus: Validate the idea works end-to-end. Skip tests, accept hardcoded values.
@@ -86,7 +88,7 @@ After POC validated, clean up code.
 
 ## Phase 3: Testing
 
-- [ ] 3.1 Unit tests for {{component}}
+- [P] 3.1 Unit tests for {{component}}
   - **Do**: Create test file at {{path}}
   - **Files**: {{test file path}}
   - **Done when**: Tests cover main functionality
@@ -95,7 +97,7 @@ After POC validated, clean up code.
   - _Requirements: AC-1.1, AC-1.2_
   - _Design: Test Strategy_
 
-- [ ] 3.2 Integration tests
+- [P] 3.2 Integration tests
   - **Do**: Create integration test at {{path}}
   - **Files**: {{test file path}}
   - **Done when**: Integration points tested


### PR DESCRIPTION
Add support for parallel task execution using [P] markers in tasks.md. Tasks marked with [P] that are consecutive will be grouped and executed simultaneously using multiple Task tool calls.

Changes:
- tasks.md template: Add [P] marker documentation and examples
- task-planner.md: Add rules for when to use parallel tasks
- stop-handler.sh: Detect consecutive [P] tasks and group them
- spec-executor.md: Add parallel execution flow using Task tool
- implement.md: Support parallel task detection at start

## What

<!-- Brief description of changes -->

## Why

<!-- Why this change is needed -->

## Testing

<!-- How you tested it -->

## Checklist

- [ ] I tested locally with `claude --plugin-dir`
- [ ] I updated documentation if needed
- [ ] My commits have clear messages
