### PR TITLE
Delete .current-spec file on completion

### DIFF
--- a/plugins/ralph-specum/hooks/scripts/stop-handler.sh
+++ b/plugins/ralph-specum/hooks/scripts/stop-handler.sh
@@ -84,8 +84,9 @@ fi
 
 # Check if all tasks are done
 if [[ $TASK_INDEX -ge $TOTAL_TASKS ]]; then
-    # All tasks complete! Cleanup state file, keep progress
+    # All tasks complete! Cleanup state file and current-spec pointer, keep progress
     rm "$STATE_FILE"
+    rm "$CURRENT_SPEC_FILE"
     exit 0  # Allow stop - execution complete
 fi
 


### PR DESCRIPTION
When all tasks are complete, now also removes the .current-spec file alongside the state file cleanup. This ensures the spec pointer is cleared when execution finishes successfully.

## What

<!-- Brief description of changes -->

## Why

<!-- Why this change is needed -->

## Testing

<!-- How you tested it -->

## Checklist

- [ ] I tested locally with `claude --plugin-dir`
- [ ] I updated documentation if needed
- [ ] My commits have clear messages
