### PR TITLE
Prevent agent from pushing to default branch

### DIFF
--- a/plugins/ralph-specum/agents/spec-executor.md
+++ b/plugins/ralph-specum/agents/spec-executor.md
@@ -98,6 +98,19 @@ Awaiting next task
 Task 2.2 description (or "All tasks complete")
 ```
 
+## Default Branch Protection
+
+<mandatory>
+NEVER push directly to the default branch (main/master). This is NON-NEGOTIABLE.
+
+If you need to push changes:
+1. First check if you're on the default branch: `git branch --show-current`
+2. If on default branch, create a new feature branch first: `git checkout -b <feature-branch-name>`
+3. Only push to feature branches: `git push -u origin <feature-branch-name>`
+
+The only exception is if the user explicitly requests pushing to the default branch.
+</mandatory>
+
 ## Commit Discipline
 
 <mandatory>

--- a/plugins/ralph-specum/agents/task-planner.md
+++ b/plugins/ralph-specum/agents/task-planner.md
@@ -198,6 +198,15 @@ After POC validated, clean up code.
 ## Phase 4: Quality Gates
 
 <mandatory>
+NEVER push directly to the default branch (main/master). Always use feature branches and PRs.
+
+If currently on the default branch:
+1. Create a new feature branch: `git checkout -b <feature-branch-name>`
+2. Push to the feature branch: `git push -u origin <feature-branch-name>`
+3. Create a PR for review
+
+The only exception is if the user explicitly requests pushing to the default branch.
+
 By default, when on a feature branch (non-default), the final deliverable is a Pull Request with passing CI.
 </mandatory>
 
@@ -212,10 +221,11 @@ By default, when on a feature branch (non-default), the final deliverable is a P
 
 - [ ] 4.2 Create PR and verify CI
   - **Do**:
-    1. Detect if on feature branch (not main/master)
-    2. Push branch: `git push -u origin <branch-name>`
-    3. Create PR using gh CLI: `gh pr create --title "<title>" --body "<summary>"`
-    4. If gh CLI unavailable, provide URL for manual PR creation
+    1. Check current branch: `git branch --show-current`
+    2. If on default branch (main/master), create a feature branch first: `git checkout -b feat/<feature-name>`
+    3. Push branch: `git push -u origin <branch-name>`
+    4. Create PR using gh CLI: `gh pr create --title "<title>" --body "<summary>"`
+    5. If gh CLI unavailable, provide URL for manual PR creation
   - **Verify**: Use gh CLI to verify CI:
     - `gh pr checks --watch` (wait for CI completion)
     - Or `gh pr checks` (poll current status)

--- a/plugins/ralph-specum/templates/tasks.md
+++ b/plugins/ralph-specum/templates/tasks.md
@@ -122,6 +122,8 @@ After POC validated, clean up code.
 
 ## Phase 4: Quality Gates
 
+> **IMPORTANT**: NEVER push directly to the default branch (main/master). Always create a feature branch first if you're on the default branch. The only exception is if the user explicitly requests pushing to the default branch.
+
 > **Default Behavior**: When on a feature branch (not main/master), the final deliverable is a Pull Request with all CI checks passing. This is the default unless explicitly stated otherwise.
 
 - [ ] 4.1 Local quality check
@@ -136,9 +138,10 @@ After POC validated, clean up code.
 - [ ] 4.2 Create PR and verify CI
   - **Do**:
     1. Check current branch: `git branch --show-current`
-    2. If on feature branch (not main/master), proceed with PR
-    3. Push branch: `git push -u origin $(git branch --show-current)`
-    4. Create PR using gh CLI (if available):
+    2. If on default branch (main/master), create a feature branch first: `git checkout -b feat/<feature-name>`
+    3. If on feature branch, proceed with PR
+    4. Push branch: `git push -u origin $(git branch --show-current)`
+    5. Create PR using gh CLI (if available):
        ```bash
        gh pr create --title "feat: {{feature-name}}" --body "## Summary
        {{brief description of changes}}
@@ -147,7 +150,7 @@ After POC validated, clean up code.
        - [x] Local quality gates pass (types, lint, tests)
        - [ ] CI checks pass"
        ```
-    5. If gh CLI unavailable, output: "Create PR at: https://github.com/<org>/<repo>/compare/<branch>"
+    6. If gh CLI unavailable, output: "Create PR at: https://github.com/<org>/<repo>/compare/<branch>"
   - **Verify**: Use gh CLI to verify CI status:
     ```bash
     # Wait for CI and watch status


### PR DESCRIPTION
Add mandatory instructions to never push directly to the default branch (main/master). Agents must always create a feature branch first if on the default branch. The only exception is explicit user request.

Updated files:
- spec-executor.md: Added Default Branch Protection section
- task-planner.md: Updated Phase 4 with branch protection rules
- templates/tasks.md: Added branch check to PR creation workflow

## What

<!-- Brief description of changes -->

## Why

<!-- Why this change is needed -->

## Testing

<!-- How you tested it -->

## Checklist

- [ ] I tested locally with `claude --plugin-dir`
- [ ] I updated documentation if needed
- [ ] My commits have clear messages
