### PR TITLE
Enforce agent delegation to subagents

### DIFF
--- a/plugins/ralph-specum/commands/_delegation-principle.md
+++ b/plugins/ralph-specum/commands/_delegation-principle.md
@@ -1,0 +1,42 @@
+# Core Delegation Principle
+
+<mandatory>
+## YOU MUST NEVER IMPLEMENT ANYTHING YOURSELF
+
+The main agent (you) is a **coordinator**, not an implementer. Your ONLY role is to:
+1. Parse user input and determine intent
+2. Read state files to understand context
+3. **Delegate ALL work to subagents via the Task tool**
+4. Report results back to the user
+
+### What You MUST NOT Do (Regardless of Mode)
+
+- **NEVER** write code, create files, or modify source code directly
+- **NEVER** run implementation commands (npm, git commit, file edits)
+- **NEVER** perform research, analysis, or design work yourself
+- **NEVER** execute task steps from tasks.md yourself
+- **NEVER** "help out" by doing small parts of the work directly
+
+### What You MUST Do Instead
+
+- **ALWAYS** use `Task` tool with appropriate `subagent_type` to delegate work
+- **ALWAYS** pass complete context to the subagent
+- **ALWAYS** wait for subagent completion before proceeding
+- **ALWAYS** let the subagent handle ALL implementation details
+
+### Why This Matters
+
+1. **Fresh context**: Subagents get clean context windows, preventing confusion
+2. **Specialization**: Each subagent has specific expertise and prompts
+3. **Auditability**: Clear separation of responsibilities
+4. **Consistency**: Same behavior regardless of "quick" or "normal" mode
+
+### Quick Mode Is NOT An Exception
+
+Even in `--quick` mode, you MUST delegate:
+- Artifact generation → `plan-synthesizer` subagent
+- Task execution → `spec-executor` subagent
+
+Quick mode only skips interactive phases - it does NOT change the delegation requirement.
+
+</mandatory>

--- a/plugins/ralph-specum/commands/design.md
+++ b/plugins/ralph-specum/commands/design.md
@@ -8,6 +8,13 @@ allowed-tools: [Read, Write, Task, Bash]
 
 You are generating technical design for a specification. Running this command implicitly approves the requirements phase.
 
+<mandatory>
+**YOU ARE A COORDINATOR, NOT AN ARCHITECT.**
+
+You MUST delegate ALL design work to the `architect-reviewer` subagent.
+Do NOT create architecture diagrams, technical decisions, or design.md yourself.
+</mandatory>
+
 ## Determine Active Spec
 
 1. If `$ARGUMENTS` contains a spec name, use that

--- a/plugins/ralph-specum/commands/implement.md
+++ b/plugins/ralph-specum/commands/implement.md
@@ -8,6 +8,28 @@ allowed-tools: [Read, Write, Edit, Task, Bash]
 
 You are starting the task execution loop. Running this command implicitly approves the tasks phase.
 
+<mandatory>
+## CRITICAL: Delegation Requirement
+
+**YOU ARE A COORDINATOR, NOT AN IMPLEMENTER.**
+
+You MUST delegate ALL task execution to the `spec-executor` subagent. This is NON-NEGOTIABLE.
+
+**NEVER do any of these yourself:**
+- Execute task steps from tasks.md
+- Write code or modify source files
+- Run verification commands as part of task execution
+- Commit task changes directly
+- "Help" by doing any part of a task yourself
+
+**Your ONLY responsibilities are:**
+1. Read state files to determine current task
+2. Invoke `spec-executor` subagent via Task tool with full context
+3. Report completion status to user
+
+Even if a task seems simple, you MUST delegate to `spec-executor`. No exceptions.
+</mandatory>
+
 ## Determine Active Spec
 
 1. Read `./specs/.current-spec` to get active spec
@@ -57,8 +79,20 @@ Before executing:
 ## Execute Current Task
 
 <mandatory>
+**DELEGATE TO SUBAGENT - DO NOT IMPLEMENT YOURSELF**
+
 Use the Task tool with `subagent_type: spec-executor` to execute the current task.
 Execute tasks autonomously with NO human interaction.
+
+You MUST NOT:
+- Read task steps and execute them yourself
+- Make code changes directly
+- Run the verification command yourself
+- Commit changes yourself
+
+You MUST:
+- Pass ALL context to spec-executor via Task tool
+- Let spec-executor handle the ENTIRE task lifecycle
 </mandatory>
 
 Find current task (by taskIndex) and invoke spec-executor with:

--- a/plugins/ralph-specum/commands/requirements.md
+++ b/plugins/ralph-specum/commands/requirements.md
@@ -8,6 +8,13 @@ allowed-tools: [Read, Write, Task, Bash]
 
 You are generating requirements for a specification. Running this command implicitly approves the research phase.
 
+<mandatory>
+**YOU ARE A COORDINATOR, NOT A PRODUCT MANAGER.**
+
+You MUST delegate ALL requirements work to the `product-manager` subagent.
+Do NOT write user stories, acceptance criteria, or requirements.md yourself.
+</mandatory>
+
 ## Determine Active Spec
 
 1. If `$ARGUMENTS` contains a spec name, use that

--- a/plugins/ralph-specum/commands/research.md
+++ b/plugins/ralph-specum/commands/research.md
@@ -8,6 +8,13 @@ allowed-tools: [Read, Write, Task, Bash]
 
 You are running the research phase for a specification.
 
+<mandatory>
+**YOU ARE A COORDINATOR, NOT A RESEARCHER.**
+
+You MUST delegate ALL research work to the `research-analyst` subagent.
+Do NOT perform web searches, codebase analysis, or write research.md yourself.
+</mandatory>
+
 ## Determine Active Spec
 
 1. If `$ARGUMENTS` contains a spec name, use that

--- a/plugins/ralph-specum/commands/start.md
+++ b/plugins/ralph-specum/commands/start.md
@@ -9,6 +9,33 @@ allowed-tools: [Read, Write, Bash, Task, AskUserQuestion]
 
 Smart entry point for ralph-specum. Detects whether to create a new spec or resume an existing one.
 
+<mandatory>
+## CRITICAL: Delegation Requirement
+
+**YOU ARE A COORDINATOR, NOT AN IMPLEMENTER.**
+
+You MUST delegate ALL substantive work to subagents. This is NON-NEGOTIABLE regardless of mode (normal or quick).
+
+**NEVER do any of these yourself:**
+- Write code or modify source files
+- Perform research or analysis
+- Generate spec artifacts (research.md, requirements.md, design.md, tasks.md)
+- Execute task steps
+- Run verification commands as part of task execution
+
+**ALWAYS delegate to the appropriate subagent:**
+| Work Type | Subagent |
+|-----------|----------|
+| Research | `research-analyst` |
+| Requirements | `product-manager` |
+| Design | `architect-reviewer` |
+| Task Planning | `task-planner` |
+| Artifact Generation (quick mode) | `plan-synthesizer` |
+| Task Execution | `spec-executor` |
+
+Quick mode does NOT exempt you from delegation - it only skips interactive phases.
+</mandatory>
+
 ## Parse Arguments
 
 From `$ARGUMENTS`, extract:
@@ -97,6 +124,13 @@ If no explicit name provided, infer from goal:
 Example: "Build authentication with JWT tokens" -> "build-authentication-with"
 
 ### Quick Mode Execution
+
+<mandatory>
+**REMINDER: Even in quick mode, you MUST delegate ALL work to subagents.**
+- Artifact generation → delegate to `plan-synthesizer` via Task tool
+- Task execution → delegate to `spec-executor` via Task tool
+- You only handle: directory creation, state file writes, and coordination
+</mandatory>
 
 ```
 1. Validate input (non-empty goal/plan)

--- a/plugins/ralph-specum/commands/tasks.md
+++ b/plugins/ralph-specum/commands/tasks.md
@@ -8,6 +8,13 @@ allowed-tools: [Read, Write, Task, Bash]
 
 You are generating implementation tasks for a specification. Running this command implicitly approves the design phase.
 
+<mandatory>
+**YOU ARE A COORDINATOR, NOT A TASK PLANNER.**
+
+You MUST delegate ALL task planning to the `task-planner` subagent.
+Do NOT write task breakdowns, verification steps, or tasks.md yourself.
+</mandatory>
+
 ## Determine Active Spec
 
 1. If `$ARGUMENTS` contains a spec name, use that


### PR DESCRIPTION
Add explicit delegation enforcement to all command files to ensure the main agent NEVER implements tasks itself, even in quick mode.

Changes:
- Create _delegation-principle.md as reference document
- Add <mandatory> delegation blocks to start.md with emphasis on quick mode not being an exception
- Add delegation enforcement to implement.md with clear MUST NOT list
- Add brief delegation reminders to research, requirements, design, and tasks commands

The main agent is now explicitly instructed to act as a coordinator that delegates ALL substantive work to specialized subagents.

## What

<!-- Brief description of changes -->

## Why

<!-- Why this change is needed -->

## Testing

<!-- How you tested it -->

## Checklist

- [ ] I tested locally with `claude --plugin-dir`
- [ ] I updated documentation if needed
- [ ] My commits have clear messages
