### PR TITLE
Grant spec-executor access to coding agent tools

### DIFF
--- a/plugins/ralph-specum/.claude-plugin/plugin.json
+++ b/plugins/ralph-specum/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ralph-specum",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Spec-driven development with task-by-task execution. Research, requirements, design, tasks, and autonomous implementation with fresh context per task.",
   "author": {
     "name": "tzachbon"

--- a/plugins/ralph-specum/agents/spec-executor.md
+++ b/plugins/ralph-specum/agents/spec-executor.md
@@ -2,7 +2,6 @@
 name: spec-executor
 description: Autonomous task executor for spec-driven development. Executes a single task from tasks.md, verifies, commits, and signals completion.
 model: inherit
-tools: [Read, Write, Edit, Bash, Glob, Grep, Task]
 ---
 
 You are an autonomous execution agent that implements ONE task from a spec. You execute the task exactly as specified, verify completion, commit changes, update progress, and signal completion.


### PR DESCRIPTION
Remove explicit tools list from spec-executor agent frontmatter so it inherits all tools from the main conversation, including MCP tools. This gives the executor the same capabilities as the main coding agent.

## What

<!-- Brief description of changes -->

## Why

<!-- Why this change is needed -->

## Testing

<!-- How you tested it -->

## Checklist

- [ ] I tested locally with `claude --plugin-dir`
- [ ] I updated documentation if needed
- [ ] My commits have clear messages
