### PR TITLE
Commit specs first after creating pull request

### DIFF
--- a/plugins/ralph-specum/.claude-plugin/plugin.json
+++ b/plugins/ralph-specum/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ralph-specum",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Spec-driven development with task-by-task execution. Research, requirements, design, tasks, and autonomous implementation with fresh context per task.",
   "author": {
     "name": "tzachbon"

--- a/plugins/ralph-specum/agents/plan-synthesizer.md
+++ b/plugins/ralph-specum/agents/plan-synthesizer.md
@@ -14,13 +14,43 @@ You are a rapid spec synthesizer that converts a user plan/goal into complete sp
 3. Generate all four artifacts in sequence
 4. Mark each with `generated: auto` frontmatter
 5. Append learnings to .progress.md
-6. **Update .ralph-state.json** to transition to execution phase
-7. Return task count for execution start
+6. **Commit all spec files** (first commit before any implementation)
+7. **Update .ralph-state.json** to transition to execution phase
+8. Return task count for execution start
+
+## Commit Specs First (Before State Transition)
+
+<mandatory>
+**COMMIT SPECS BEFORE TRANSITIONING TO EXECUTION**
+
+After generating all artifacts and before updating the state to execution phase, commit all spec files. This ensures:
+- Specs are version-controlled before any code changes
+- The first commit after branch creation contains the complete spec
+- Clear separation between spec definition and implementation
+
+```bash
+# Stage all generated spec files
+git add ./specs/<spec>/research.md ./specs/<spec>/requirements.md ./specs/<spec>/design.md ./specs/<spec>/tasks.md ./specs/<spec>/.progress.md 2>/dev/null
+
+# Commit with descriptive message
+git commit -m "docs(spec): add spec for <spec>
+
+Spec artifacts:
+- research.md: feasibility analysis and codebase exploration
+- requirements.md: user stories and acceptance criteria
+- design.md: architecture and technical decisions
+- tasks.md: POC-first implementation plan
+
+Ready for implementation."
+```
+
+This step is NON-NEGOTIABLE. Specs must be committed before any implementation begins.
+</mandatory>
 
 ## State Transition (CRITICAL)
 
 <mandatory>
-After generating tasks.md, you MUST update the state file to enable the task execution loop.
+After committing specs and generating tasks.md, you MUST update the state file to enable the task execution loop.
 
 **Read the current state:**
 ```bash

--- a/plugins/ralph-specum/commands/implement.md
+++ b/plugins/ralph-specum/commands/implement.md
@@ -65,6 +65,53 @@ Update `.ralph-state.json`:
 }
 ```
 
+## Commit Specs First (Before Any Implementation)
+
+<mandatory>
+**COMMIT SPECS BEFORE STARTING IMPLEMENTATION**
+
+Before executing any tasks, commit all spec files. This ensures:
+- Specs are version-controlled before any code changes
+- Clear separation between spec definition and implementation
+- Spec history is preserved even if implementation fails
+</mandatory>
+
+### Check If Specs Already Committed
+
+Check if this is a fresh start (taskIndex == 0 after initialization) and specs haven't been committed yet:
+
+```bash
+# Check if any spec files are uncommitted or untracked
+git status --porcelain ./specs/$spec/*.md ./specs/$spec/.progress.md 2>/dev/null | grep -q '.' && echo "uncommitted" || echo "clean"
+```
+
+### Commit Spec Files
+
+If specs are uncommitted (new or modified), commit them:
+
+```bash
+# Stage all spec files
+git add ./specs/$spec/research.md ./specs/$spec/requirements.md ./specs/$spec/design.md ./specs/$spec/tasks.md ./specs/$spec/.progress.md 2>/dev/null
+
+# Commit with descriptive message
+git commit -m "docs(spec): add spec for $spec
+
+Spec artifacts:
+- research.md: feasibility analysis and codebase exploration
+- requirements.md: user stories and acceptance criteria
+- design.md: architecture and technical decisions
+- tasks.md: POC-first implementation plan
+
+Ready for implementation."
+```
+
+If commit succeeds, output:
+```
+Committed spec files for '$spec'
+```
+
+If nothing to commit (specs already committed), continue silently.
+
 ## Read Context
 
 Before executing:


### PR DESCRIPTION
Add mandatory step to commit all spec files (research.md, requirements.md, design.md, tasks.md, .progress.md) as the first commit after branch creation, before any implementation work begins.

Changes:
- implement.md: Added "Commit Specs First" section that stages and commits spec files before invoking spec-executor
- plan-synthesizer.md: Added spec commit step for quick mode, ensuring specs are committed before transitioning to execution phase

This ensures:
- Specs are version-controlled before any code changes
- Clear separation between spec definition and implementation
- Spec history is preserved even if implementation fails

Bump version to 1.1.3

## What

<!-- Brief description of changes -->

## Why

<!-- Why this change is needed -->

## Testing

<!-- How you tested it -->

## Checklist

- [ ] I tested locally with `claude --plugin-dir`
- [ ] I updated documentation if needed
- [ ] My commits have clear messages
