### PR TITLE
Add feedback command with GitHub issue integration

### DIFF
--- a/plugins/ralph-specum/.claude-plugin/plugin.json
+++ b/plugins/ralph-specum/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ralph-specum",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Spec-driven development with task-by-task execution. Research, requirements, design, tasks, and autonomous implementation with fresh context per task.",
   "author": {
     "name": "tzachbon"

--- a/plugins/ralph-specum/commands/feedback.md
+++ b/plugins/ralph-specum/commands/feedback.md
@@ -1,0 +1,40 @@
+---
+description: Submit feedback or report an issue for Ralph Specum plugin.
+arguments:
+  - name: message
+    description: Your feedback or issue description
+    required: false
+---
+
+# Submit Feedback
+
+Help improve Ralph Specum by submitting feedback or reporting issues.
+
+## Instructions
+
+1. **Check if `gh` CLI is available** by running: `which gh`
+
+2. **If `gh` is available**, create an issue with the user's feedback:
+   ```bash
+   gh issue create --repo tzachbon/smart-ralph --title "<short title from feedback>" --body "<full feedback message>"
+   ```
+   - Extract a short, descriptive title from the feedback
+   - Include the full feedback in the body
+   - Add the label `feedback` if it exists
+
+3. **If `gh` is NOT available**, inform the user:
+   > The `gh` CLI is not installed or not authenticated. Please submit your feedback manually at:
+   >
+   > **https://github.com/tzachbon/smart-ralph/issues/new**
+   >
+   > Or browse existing issues: https://github.com/tzachbon/smart-ralph/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen
+
+4. **If no message was provided**, ask the user what feedback they'd like to submit.
+
+## Example Usage
+
+```
+/ralph-specum:feedback The task verification system sometimes misses TASK_COMPLETE markers
+/ralph-specum:feedback Feature request: add support for parallel task execution
+/ralph-specum:feedback Bug: cancel command doesn't cleanup .ralph-state.json properly
+```

--- a/plugins/ralph-specum/commands/help.md
+++ b/plugins/ralph-specum/commands/help.md
@@ -22,6 +22,7 @@ Ralph Specum is a spec-driven development plugin that guides you through researc
 | `/ralph-specum:status` | Show all specs and progress |
 | `/ralph-specum:switch <name>` | Change active spec |
 | `/ralph-specum:cancel` | Cancel active loop, cleanup state |
+| `/ralph-specum:feedback [message]` | Submit feedback or report an issue |
 | `/ralph-specum:help` | Show this help |
 
 ## Workflow


### PR DESCRIPTION
- Add /ralph-specum:feedback command that uses gh CLI to create issues
- Falls back to providing GitHub issues URL if gh is unavailable
- Update help.md to include the new command
- Bump version to 1.2.3

## What

<!-- Brief description of changes -->

## Why

<!-- Why this change is needed -->

## Testing

<!-- How you tested it -->

## Checklist

- [ ] I tested locally with `claude --plugin-dir`
- [ ] I updated documentation if needed
- [ ] My commits have clear messages
