### PR TITLE
Add GitHub CI workflow for spec validation

### DIFF
--- a/.github/workflows/spec-file-check.yml
+++ b/.github/workflows/spec-file-check.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: Checkout PR branch
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
 
       - name: Check for .current-spec file
         run: |


### PR DESCRIPTION
Add a GitHub Actions workflow that fails PRs if they include the specs/.current-spec file, which is meant for local state tracking only.

## What

<!-- Brief description of changes -->

## Why

<!-- Why this change is needed -->

## Testing

<!-- How you tested it -->

## Checklist

- [ ] I tested locally with `claude --plugin-dir`
- [ ] I updated documentation if needed
- [ ] My commits have clear messages
