### PR TITLE
Fix Ralph loop execution issue

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "ralph-specum",
       "description": "Spec-driven development with research, requirements, design, tasks, and autonomous execution. Fresh context per task.",
-      "version": "2.5.3",
+      "version": "2.5.4",
       "author": {
         "name": "tzachbon"
       },

--- a/plugins/ralph-specum/.claude-plugin/plugin.json
+++ b/plugins/ralph-specum/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ralph-specum",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "description": "Spec-driven development with task-by-task execution. Research, requirements, design, tasks, and autonomous implementation with fresh context per task.",
   "author": {
     "name": "tzachbon"

--- a/plugins/ralph-specum/commands/implement.md
+++ b/plugins/ralph-specum/commands/implement.md
@@ -12,7 +12,7 @@ You are starting the task execution loop.
 
 **BEFORE proceeding**, verify Ralph Wiggum plugin is installed by attempting to invoke the skill.
 
-If the Skill tool fails with "skill not found" or similar error for `ralph-wiggum:ralph-loop`:
+If the Skill tool fails with "skill not found" or similar error for `ralph-loop:ralph-loop`:
 1. Output error: "ERROR: Ralph Wiggum plugin not found. Install with: /plugin install ralph-loop@claude-plugins-official"
 2. STOP execution immediately. Do NOT continue.
 

--- a/plugins/ralph-specum/commands/start.md
+++ b/plugins/ralph-specum/commands/start.md
@@ -156,7 +156,7 @@ In quick mode (`--quick`), execution uses `/ralph-loop` for autonomous task comp
 
 After generating spec artifacts in quick mode, invoke ralph-loop:
 ```
-Skill: ralph-wiggum:ralph-loop
+Skill: ralph-loop:ralph-loop
 Args: Read ./specs/$spec/.coordinator-prompt.md and follow those instructions exactly. Output ALL_TASKS_COMPLETE when done. --max-iterations <calculated> --completion-promise ALL_TASKS_COMPLETE
 ```
 


### PR DESCRIPTION
The skill name was incorrectly specified as `ralph-wiggum:ralph-loop` when the actual plugin namespace is `ralph-loop`. This caused the implement command to fail to invoke the ralph loop.

## What

<!-- Brief description of changes -->

## Why

<!-- Why this change is needed -->

## Testing

<!-- How you tested it -->

## Checklist

- [ ] I tested locally with `claude --plugin-dir`
- [ ] I updated documentation if needed
- [ ] My commits have clear messages
