### PR TITLE
Fix Ralph Loop plugin name and add marketplace setup docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,13 @@ Spec-executor must output `TASK_COMPLETE` for coordinator to advance. Coordinato
 
 ### Dependencies
 
-Requires Ralph Loop plugin: `/plugin install ralph-wiggum@claude-plugins-official`
+Requires Ralph Loop plugin: `/plugin install ralph-loop@claude-plugins-official`
+
+**Note:** If you see "marketplace not found" errors, first add the official marketplace:
+```bash
+/plugin marketplace add anthropics/claude-code
+/plugin install ralph-loop@claude-plugins-official
+```
 
 ## Key Files
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -17,7 +17,16 @@ v2.0.0 delegates task execution to the official Ralph Loop plugin instead of usi
 
 1. **Install Ralph Loop**
    ```bash
-   /plugin install ralph-wiggum@claude-plugins-official
+   /plugin install ralph-loop@claude-plugins-official
+   ```
+
+   **If marketplace not found:**
+   ```bash
+   # Add the official marketplace first
+   /plugin marketplace add anthropics/claude-code
+
+   # Then install Ralph Loop
+   /plugin install ralph-loop@claude-plugins-official
    ```
 
 2. **Restart Claude Code**
@@ -57,7 +66,8 @@ The new loop picks up from the last completed task.
 ### Troubleshooting
 
 **"Ralph Loop plugin not found"**
-- Install it: `/plugin install ralph-wiggum@claude-plugins-official`
+- Install it: `/plugin install ralph-loop@claude-plugins-official`
+- If marketplace not found: `/plugin marketplace add anthropics/claude-code`
 - Restart Claude Code
 
 **"Loop state conflict"**

--- a/README.md
+++ b/README.md
@@ -42,8 +42,10 @@ Named after the [Ralph agentic loop pattern](https://ghuntley.com/ralph/) and ev
 **v2.0.0+** requires the Ralph Loop plugin for task execution:
 
 ```bash
-/plugin install ralph-wiggum@claude-plugins-official
+/plugin install ralph-loop@claude-plugins-official
 ```
+
+**Note:** The plugin is named `ralph-loop` (implementing the Ralph Wiggum technique). Some documentation may reference `ralph-wiggum` - both refer to the same plugin, use `ralph-loop`.
 
 Ralph Loop provides the execution loop. Smart Ralph provides the spec-driven workflow on top.
 
@@ -51,12 +53,28 @@ Ralph Loop provides the execution loop. Smart Ralph provides the spec-driven wor
 
 ## Installation
 
-### From Marketplace
+### Step 1: Install Ralph Loop Dependency
+
+First, ensure you have the Ralph Loop plugin installed:
 
 ```bash
-# Install Ralph Loop dependency first
-/plugin install ralph-wiggum@claude-plugins-official
+/plugin install ralph-loop@claude-plugins-official
+```
 
+**Troubleshooting:** If you get a "marketplace not found" error:
+```bash
+# Add the official marketplace (if not already added)
+/plugin marketplace add anthropics/claude-code
+
+# Then install Ralph Loop
+/plugin install ralph-loop@claude-plugins-official
+```
+
+### Step 2: Install Smart Ralph
+
+#### From Marketplace
+
+```bash
 # Add the marketplace
 /plugin marketplace add tzachbon/smart-ralph
 
@@ -66,21 +84,15 @@ Ralph Loop provides the execution loop. Smart Ralph provides the spec-driven wor
 # Restart Claude Code
 ```
 
-### From GitHub
+#### From GitHub
 
 ```bash
-# Install Ralph Loop dependency first
-/plugin install ralph-wiggum@claude-plugins-official
-
 /plugin install https://github.com/tzachbon/smart-ralph
 ```
 
-### Local Development
+#### Local Development
 
 ```bash
-# Install Ralph Loop dependency first
-/plugin install ralph-wiggum@claude-plugins-official
-
 git clone https://github.com/tzachbon/smart-ralph.git
 cd smart-ralph/plugins/ralph-specum
 claude --plugin-dir $(pwd)
@@ -243,7 +255,7 @@ Specs live in `./specs/` in your project:
 
 ```bash
 # Install Ralph Loop dependency first
-/plugin install ralph-wiggum@claude-plugins-official
+/plugin install ralph-loop@claude-plugins-official
 
 # Install ralph-speckit
 /plugin install ralph-speckit@smart-ralph
@@ -308,7 +320,13 @@ Specs live in `./specs/` in your project:
 ## Troubleshooting
 
 **"Ralph Loop plugin not found"?**
-Install the dependency: `/plugin install ralph-wiggum@claude-plugins-official`
+Install the dependency: `/plugin install ralph-loop@claude-plugins-official`
+
+If still not found, add the official marketplace first:
+```bash
+/plugin marketplace add anthropics/claude-code
+/plugin install ralph-loop@claude-plugins-official
+```
 
 **"stop-handler.sh: No such file or directory"?**
 Old v1.x installation conflict. Reinstall the plugin or see [TROUBLESHOOTING.md](TROUBLESHOOTING.md).
@@ -340,7 +358,7 @@ Starting with v2.0.0, Smart Ralph delegates task execution to the official Ralph
 **Migration from v1.x:** See [MIGRATION.md](MIGRATION.md) for detailed guide.
 
 Quick version:
-1. Install Ralph Loop: `/plugin install ralph-wiggum@claude-plugins-official`
+1. Install Ralph Loop: `/plugin install ralph-loop@claude-plugins-official`
 2. Restart Claude Code
 3. Existing specs continue working. No spec file changes needed.
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -12,10 +12,21 @@ Smart Ralph v2.0.0+ requires the Ralph Loop plugin as a dependency.
 
 **Solution:**
 ```bash
-/plugin install ralph-wiggum@claude-plugins-official
+/plugin install ralph-loop@claude-plugins-official
+```
+
+**If marketplace not found:**
+```bash
+# Add the official marketplace first
+/plugin marketplace add anthropics/claude-code
+
+# Then install Ralph Loop
+/plugin install ralph-loop@claude-plugins-official
 ```
 
 Then restart Claude Code.
+
+**Note:** The plugin is named `ralph-loop` (not `ralph-wiggum`). Both names refer to the same Ralph Wiggum technique, but the actual plugin name is `ralph-loop`.
 
 ---
 


### PR DESCRIPTION
## What

Updated all documentation to reflect the correct Ralph Loop plugin name (`ralph-loop` instead of `ralph-wiggum`) and added comprehensive troubleshooting guidance for marketplace setup issues.

## Why

The plugin identifier in the official marketplace is `ralph-loop@claude-plugins-official`, not `ralph-wiggum@claude-plugins-official`. Users following the old documentation would encounter installation failures. Additionally, users without the official marketplace pre-configured need clear instructions to add it before installing the plugin.

## Changes

- **Plugin name correction**: Updated all references from `ralph-wiggum` to `ralph-loop` across all documentation files
- **Marketplace setup docs**: Added clear instructions for adding the official marketplace (`anthropics/claude-code`) when users encounter "marketplace not found" errors
- **Clarification note**: Added explanatory note that the plugin is named `ralph-loop` (implementing the Ralph Wiggum technique) to reduce confusion
- **Improved installation flow**: Reorganized README installation section to clearly separate Ralph Loop dependency installation (Step 1) from Smart Ralph installation (Step 2)
- **Consistent troubleshooting**: Updated troubleshooting sections in CLAUDE.md, MIGRATION.md, README.md, and TROUBLESHOOTING.md with marketplace setup guidance

## Testing

- [ ] I tested locally with `claude --plugin-dir`
- [x] I updated documentation if needed
- [x] My commits have clear messages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions and troubleshooting guides across multiple documentation files.
  * Added clarification notes and fallback steps for marketplace configuration issues.
  * Restructured installation steps into clear, sequential format for improved user guidance.
  * Enhanced troubleshooting section with detailed resolution steps.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->