### PR TITLE
Bump ralph-specum to v2.8.0 and improve cancel command

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "ralph-specum",
       "description": "Spec-driven development with research, requirements, design, tasks, and autonomous execution. Fresh context per task.",
-      "version": "2.7.0",
+      "version": "2.8.0",
       "author": {
         "name": "tzachbon"
       },

--- a/plugins/ralph-specum/.claude-plugin/plugin.json
+++ b/plugins/ralph-specum/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ralph-specum",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "description": "Spec-driven development with task-by-task execution. Research, requirements, design, tasks, and autonomous implementation with fresh context per task.",
   "author": {
     "name": "tzachbon"

--- a/plugins/ralph-specum/commands/cancel.md
+++ b/plugins/ralph-specum/commands/cancel.md
@@ -1,12 +1,12 @@
 ---
-description: Cancel active execution loop and cleanup state
+description: Cancel active execution loop, cleanup state, and remove spec
 argument-hint: [spec-name]
 allowed-tools: [Read, Bash, Task]
 ---
 
 # Cancel Execution
 
-You are canceling the active execution loop and cleaning up state files.
+You are canceling the active execution loop, cleaning up state files, and removing the spec directory.
 
 ## Determine Target Spec
 
@@ -39,7 +39,15 @@ If state file exists, read and display:
    rm ./specs/$spec/.ralph-state.json
    ```
 
-3. Keep `.progress.md` as it contains valuable context
+3. Remove spec directory:
+   ```bash
+   rm -rf ./specs/$spec
+   ```
+
+4. Clear current spec marker:
+   ```bash
+   rm -f ./specs/.current-spec
+   ```
 
 ## Output
 
@@ -54,18 +62,30 @@ State before cancellation:
 Cleanup:
 - [x] Stopped Ralph loop (/ralph-loop:cancel-ralph)
 - [x] Removed .ralph-state.json
-- [ ] Kept .progress.md (contains history)
+- [x] Removed spec directory (./specs/$spec)
+- [x] Cleared current spec marker
 
-To resume later:
-- Run /ralph-specum:implement to restart execution
-- Progress file retains completed tasks and learnings
+The spec and all its files have been permanently removed.
+
+To start a new spec:
+- Run /ralph-specum:new <name>
+- Or /ralph-specum:start <name> <goal>
 ```
 
 ## If No Active Loop
 
-```
-No active execution loop found.
+If there's no `.ralph-state.json`, still proceed with removing the spec directory and clearing `.current-spec`:
 
-To start a new spec: /ralph-specum:new <name>
-To check status: /ralph-specum:status
+```
+No active execution loop found for spec: $spec
+
+Cleanup:
+- [x] Removed spec directory (./specs/$spec)
+- [x] Cleared current spec marker
+
+The spec has been removed.
+
+To start a new spec:
+- Run /ralph-specum:new <name>
+- Or /ralph-specum:start <name> <goal>
 ```


### PR DESCRIPTION
## What

- Bumped ralph-specum plugin version from 2.7.0 to 2.8.0
- Enhanced the cancel command to fully remove spec directories and clear the current spec marker
- Updated cancel command documentation to reflect the new behavior

## Why

The previous cancel command only cleaned up state files but left the spec directory intact. This change makes the cancel operation more thorough by:
- Removing the entire spec directory (`./specs/$spec`) to ensure complete cleanup
- Clearing the current spec marker (`.current-spec`) to reset the plugin state
- Providing clearer user guidance on how to start a new spec after cancellation

This ensures a clean slate when canceling execution and prevents confusion about leftover spec files.

## Testing

- [ ] I tested locally with `claude --plugin-dir`
- [ ] I updated documentation if needed
- [ ] My commits have clear messages

## Notes

The cancel command now performs complete cleanup including:
1. Stopping the Ralph execution loop
2. Removing the `.ralph-state.json` file
3. Removing the entire spec directory
4. Clearing the `.current-spec` marker file

Updated output messages to reflect all cleanup steps and provide clear next steps for users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced cancel command to remove the spec directory and clear the current spec marker, providing more comprehensive cleanup.

* **Release**
  * Version updated to 2.8.0

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->