### PR TITLE
fix(codex): enforce sub-agent delegation and stop-before-continue

### DIFF
--- a/plugins/ralph-specum-codex/.codex-plugin/plugin.json
+++ b/plugins/ralph-specum-codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ralph-specum-codex",
-  "version": "4.9.1",
+  "version": "4.10.0",
   "description": "Spec-driven development for OpenAI Codex. Research, requirements, design, tasks, autonomous implementation, and epic triage for multi-spec feature decomposition.",
   "author": {
     "name": "tzachbon"

--- a/plugins/ralph-specum-codex/references/parity-matrix.md
+++ b/plugins/ralph-specum-codex/references/parity-matrix.md
@@ -36,7 +36,7 @@ Codex:
 
 Claude uses subagents like `research-analyst` and `spec-executor`.
 
-Codex skills should preserve the same responsibilities, but the skill itself may execute the work in one session instead of requiring Claude plugin subagent dispatch.
+Codex skills MUST delegate phase work to sub-agents, matching the Claude Code delegation model. The skill acts as coordinator: gather context, run interview, delegate to the appropriate agent type, validate output, present for approval. The skill MUST NOT write spec artifacts (research.md, requirements.md, design.md, tasks.md) directly.
 
 ### Worktrees
 

--- a/plugins/ralph-specum-codex/references/workflow.md
+++ b/plugins/ralph-specum-codex/references/workflow.md
@@ -46,7 +46,7 @@ The coordinator MUST NOT write spec artifacts directly. If sub-agent delegation 
 
 1. Resolve current repo state, branch, and spec roots.
 2. Start or resume a spec.
-3. STOP and wait for explicit direction to continue to research unless `--quick`.
+3. STOP. Wait for explicit direction to continue to research unless `--quick`.
 4. Delegate `research.md` to `research-analyst` sub-agent. STOP and request approval unless `--quick`.
 5. Delegate `requirements.md` to `product-manager` sub-agent. STOP and request approval unless `--quick`.
 6. Delegate `design.md` to `architect-reviewer` sub-agent. STOP and request approval unless `--quick`.

--- a/plugins/ralph-specum-codex/references/workflow.md
+++ b/plugins/ralph-specum-codex/references/workflow.md
@@ -19,16 +19,39 @@
 | `/ralph-specum:feedback` | `$ralph-specum` or `$ralph-specum-feedback` |
 | `/ralph-specum:help` | `$ralph-specum` or `$ralph-specum-help` |
 
+## Delegation Rules
+
+Every phase skill acts as a coordinator. The coordinator:
+
+1. Gathers context (spec state, progress, prior artifacts)
+2. Runs the brainstorming interview (skip if `--quick`)
+3. Delegates artifact generation to the appropriate sub-agent type
+4. Validates the sub-agent output exists and is well-formed
+5. Presents the walkthrough summary
+6. Waits for user approval (skip if `--quick`)
+
+| Phase | Sub-agent type |
+|-------|---------------|
+| Research | `research-analyst` |
+| Requirements | `product-manager` |
+| Design | `architect-reviewer` |
+| Tasks | `task-planner` |
+| Implement | `spec-executor` (per task) |
+| Triage | `triage-analyst` |
+| Refactor | `refactor-specialist` |
+
+The coordinator MUST NOT write spec artifacts directly. If sub-agent delegation is unavailable, report the limitation and stop.
+
 ## Normal Flow
 
 1. Resolve current repo state, branch, and spec roots.
 2. Start or resume a spec.
-3. Wait for explicit direction to continue to research unless the user explicitly asked for quick or autonomous flow.
-4. Create `research.md` and request approval, changes, or continuation to requirements.
-5. Draft `requirements.md` and request approval, changes, or continuation to design.
-6. Prepare `design.md` and request approval, changes, or continuation to tasks.
-7. Compile `tasks.md` and request approval, changes, or continuation to implementation.
-8. Implement tasks until complete or blocked.
+3. STOP and wait for explicit direction to continue to research unless `--quick`.
+4. Delegate `research.md` to `research-analyst` sub-agent. STOP and request approval unless `--quick`.
+5. Delegate `requirements.md` to `product-manager` sub-agent. STOP and request approval unless `--quick`.
+6. Delegate `design.md` to `architect-reviewer` sub-agent. STOP and request approval unless `--quick`.
+7. Delegate `tasks.md` to `task-planner` sub-agent. STOP and request approval unless `--quick`.
+8. Delegate each task to `spec-executor` sub-agent until complete or blocked.
 9. Use `status`, `switch`, `cancel`, `index`, `refactor`, `feedback`, and `help` as needed.
 
 ## Start And New

--- a/plugins/ralph-specum-codex/skills/ralph-specum-design/SKILL.md
+++ b/plugins/ralph-specum-codex/skills/ralph-specum-design/SKILL.md
@@ -25,7 +25,7 @@ You are a **coordinator, not an architect** -- delegate ALL work to an `architec
 4. Use the current brainstorming interview style unless quick mode is active.
 5. **Delegate** design generation to an `architect-reviewer` sub-agent. Pass requirements, research, and interview context. The sub-agent writes `design.md`. Do NOT write design.md yourself.
 6. Read the sub-agent's output and validate it exists.
-7. Merge state with `phase: "design"` and `awaitingApproval: true`.
+7. Merge state with `phase: "design"` and `awaitingApproval: true` (or `false` when `--quick` is active).
 8. Update `.progress.md` with design decisions, open risks, integration contracts, and next step.
 9. If spec commits are enabled, commit only the spec artifacts.
 

--- a/plugins/ralph-specum-codex/skills/ralph-specum-design/SKILL.md
+++ b/plugins/ralph-specum-codex/skills/ralph-specum-design/SKILL.md
@@ -8,7 +8,7 @@ metadata:
 
 # Ralph Specum Design
 
-Use this for the design phase.
+You are a **coordinator, not an architect** -- delegate ALL work to an `architect-reviewer` sub-agent.
 
 ## Contract
 
@@ -23,11 +23,16 @@ Use this for the design phase.
 2. Require `requirements.md`. Read `research.md` when present, `.progress.md`, and current state.
 3. Clear any prior approval gate by merging `awaitingApproval: false` before generation.
 4. Use the current brainstorming interview style unless quick mode is active.
-5. Write or rewrite `design.md`.
-6. Merge state with `phase: "design"` and `awaitingApproval: true`.
-7. Update `.progress.md` with design decisions, open risks, integration contracts, and next step.
-8. If spec commits are enabled, commit only the spec artifacts.
-9. In quick mode, continue directly into tasks.
+5. **Delegate** design generation to an `architect-reviewer` sub-agent. Pass requirements, research, and interview context. The sub-agent writes `design.md`. Do NOT write design.md yourself.
+6. Read the sub-agent's output and validate it exists.
+7. Merge state with `phase: "design"` and `awaitingApproval: true`.
+8. Update `.progress.md` with design decisions, open risks, integration contracts, and next step.
+9. If spec commits are enabled, commit only the spec artifacts.
+
+### Stop Behavior
+
+- **Without `--quick`**: STOP HERE. Display the walkthrough summary and approval prompt. Do NOT continue to tasks. Wait for the user to explicitly approve and request the next phase.
+- **With `--quick`**: Continue directly into tasks.
 
 ## Output Shape
 

--- a/plugins/ralph-specum-codex/skills/ralph-specum-implement/SKILL.md
+++ b/plugins/ralph-specum-codex/skills/ralph-specum-implement/SKILL.md
@@ -8,7 +8,7 @@ metadata:
 
 # Ralph Specum Implement
 
-Use this for the implementation phase.
+You are a **coordinator, not an executor** -- delegate each task to a `spec-executor` sub-agent.
 
 ## Contract
 
@@ -29,7 +29,7 @@ Use this for the implementation phase.
    - `totalTasks: total`
    - `taskIndex: next_index`
    - preserve `taskIteration`, `maxTaskIterations`, `globalIteration`, `maxGlobalIterations`, `commitSpec`, and `relatedSpecs`
-5. Execute tasks in order until complete or blocked.
+5. **Delegate** each task to a `spec-executor` sub-agent. Pass the task description, file targets, success criteria, and context from `.progress.md`. The sub-agent implements the task and outputs `TASK_COMPLETE`. Do NOT implement tasks yourself. Execute tasks in order until complete or blocked.
 6. `[P]` tasks may batch only when file sets do not overlap and verification is independent.
 7. `[VERIFY]` tasks stay in the same run and must produce explicit verification evidence.
 8. Marker syntax must be explicitly present in `tasks.md`. If markers are absent, treat tasks as non-batchable by default.

--- a/plugins/ralph-specum-codex/skills/ralph-specum-refactor/SKILL.md
+++ b/plugins/ralph-specum-codex/skills/ralph-specum-refactor/SKILL.md
@@ -8,7 +8,7 @@ metadata:
 
 # Ralph Specum Refactor
 
-Use this to revise spec artifacts after implementation learnings.
+You are a **coordinator, not a refactor specialist** -- delegate spec revision to a `refactor-specialist` sub-agent.
 
 ## Contract
 
@@ -20,9 +20,9 @@ Use this to revise spec artifacts after implementation learnings.
 
 1. Resolve the target spec.
 2. Read `.progress.md` and existing spec files.
-3. Identify what implementation changed, what stayed accurate, and what is now obsolete.
-4. Preserve newer Ralph concepts already expressed in the spec, including approval checkpoints, granularity choices, `[P]` tasks, `[VERIFY]` tasks, VE tasks, and epic constraints when relevant.
-5. Update files in order:
+3. **Delegate** spec revision to a `refactor-specialist` sub-agent. Pass `.progress.md`, existing spec files, and implementation learnings. The sub-agent identifies what changed, what stayed accurate, and what is obsolete. Do NOT revise spec files yourself.
+4. The sub-agent preserves newer Ralph concepts already expressed in the spec, including approval checkpoints, granularity choices, `[P]` tasks, `[VERIFY]` tasks, VE tasks, and epic constraints when relevant.
+5. The sub-agent updates files in order:
    - `requirements.md`
    - `design.md`
    - `tasks.md`

--- a/plugins/ralph-specum-codex/skills/ralph-specum-requirements/SKILL.md
+++ b/plugins/ralph-specum-codex/skills/ralph-specum-requirements/SKILL.md
@@ -25,7 +25,7 @@ You are a **coordinator, not a product manager** -- delegate ALL work to a `prod
 4. Use the current brainstorming interview style unless quick mode is active.
 5. **Delegate** requirements generation to a `product-manager` sub-agent. Pass research context, goal, and interview results. The sub-agent writes `requirements.md`. Do NOT write requirements.md yourself.
 6. Read the sub-agent's output and validate it exists.
-7. Merge state with `phase: "requirements"` and `awaitingApproval: true`.
+7. Merge state with `phase: "requirements"` and `awaitingApproval: true` (or `false` when `--quick` is active).
 8. Update `.progress.md` with approved research context, user decisions, blockers, next step, and any epic constraints that must carry forward.
 9. If spec commits are enabled, commit only the spec artifacts.
 

--- a/plugins/ralph-specum-codex/skills/ralph-specum-requirements/SKILL.md
+++ b/plugins/ralph-specum-codex/skills/ralph-specum-requirements/SKILL.md
@@ -8,7 +8,7 @@ metadata:
 
 # Ralph Specum Requirements
 
-Use this for the requirements phase.
+You are a **coordinator, not a product manager** -- delegate ALL work to a `product-manager` sub-agent.
 
 ## Contract
 
@@ -23,11 +23,16 @@ Use this for the requirements phase.
 2. Read `research.md` when present, `.progress.md`, and the current state.
 3. Clear any prior approval gate by merging `awaitingApproval: false` before generation.
 4. Use the current brainstorming interview style unless quick mode is active.
-5. Write or rewrite `requirements.md`.
-6. Merge state with `phase: "requirements"` and `awaitingApproval: true`.
-7. Update `.progress.md` with approved research context, user decisions, blockers, next step, and any epic constraints that must carry forward.
-8. If spec commits are enabled, commit only the spec artifacts.
-9. In quick mode, continue directly into design.
+5. **Delegate** requirements generation to a `product-manager` sub-agent. Pass research context, goal, and interview results. The sub-agent writes `requirements.md`. Do NOT write requirements.md yourself.
+6. Read the sub-agent's output and validate it exists.
+7. Merge state with `phase: "requirements"` and `awaitingApproval: true`.
+8. Update `.progress.md` with approved research context, user decisions, blockers, next step, and any epic constraints that must carry forward.
+9. If spec commits are enabled, commit only the spec artifacts.
+
+### Stop Behavior
+
+- **Without `--quick`**: STOP HERE. Display the walkthrough summary and approval prompt. Do NOT continue to design. Wait for the user to explicitly approve and request the next phase.
+- **With `--quick`**: Continue directly into design.
 
 ## Output Shape
 

--- a/plugins/ralph-specum-codex/skills/ralph-specum-research/SKILL.md
+++ b/plugins/ralph-specum-codex/skills/ralph-specum-research/SKILL.md
@@ -25,7 +25,7 @@ You are a **coordinator, not a researcher** -- delegate ALL work to a `research-
 3. Use the current brainstorming interview style unless quick mode is active.
 4. **Delegate** research generation to a `research-analyst` sub-agent. Pass the goal, existing context, and interview results. The sub-agent writes `research.md` in the spec directory. Do NOT write research.md yourself.
 5. Read the sub-agent's output and validate it exists.
-6. Merge state with `phase: "research"` and `awaitingApproval: true`.
+6. Merge state with `phase: "research"` and `awaitingApproval: true` (or `false` when `--quick` is active).
 7. Update `.progress.md` with the research summary, blockers, learnings, next step, and verification tooling notes when relevant.
 8. If spec commits are enabled, commit only the spec artifacts.
 

--- a/plugins/ralph-specum-codex/skills/ralph-specum-research/SKILL.md
+++ b/plugins/ralph-specum-codex/skills/ralph-specum-research/SKILL.md
@@ -8,7 +8,7 @@ metadata:
 
 # Ralph Specum Research
 
-Use this for the research phase.
+You are a **coordinator, not a researcher** -- delegate ALL work to a `research-analyst` sub-agent.
 
 ## Contract
 
@@ -23,11 +23,16 @@ Use this for the research phase.
 1. Resolve the active spec. If none exists, stop and tell the user to start a spec first.
 2. Read the goal, `.progress.md`, current state, indexed codebase context, related specs, and epic context when present.
 3. Use the current brainstorming interview style unless quick mode is active.
-4. Write or rewrite `research.md` in the spec directory.
-5. Merge state with `phase: "research"` and `awaitingApproval: true`.
-6. Update `.progress.md` with the research summary, blockers, learnings, next step, and verification tooling notes when relevant.
-7. If spec commits are enabled, commit only the spec artifacts.
-8. In quick mode, continue directly into requirements.
+4. **Delegate** research generation to a `research-analyst` sub-agent. Pass the goal, existing context, and interview results. The sub-agent writes `research.md` in the spec directory. Do NOT write research.md yourself.
+5. Read the sub-agent's output and validate it exists.
+6. Merge state with `phase: "research"` and `awaitingApproval: true`.
+7. Update `.progress.md` with the research summary, blockers, learnings, next step, and verification tooling notes when relevant.
+8. If spec commits are enabled, commit only the spec artifacts.
+
+### Stop Behavior
+
+- **Without `--quick`**: STOP HERE. Display the walkthrough summary and approval prompt. Do NOT continue to requirements. Wait for the user to explicitly approve and request the next phase.
+- **With `--quick`**: Continue directly into requirements.
 
 ## Output Shape
 

--- a/plugins/ralph-specum-codex/skills/ralph-specum-start/SKILL.md
+++ b/plugins/ralph-specum-codex/skills/ralph-specum-start/SKILL.md
@@ -48,7 +48,7 @@ Use this for the `start` and `new` entrypoints.
 9. Write `.progress.md` with goal, current phase, next step, blockers, learnings, and skill discovery results when used.
 10. On resume, prefer `tasks.md` and present files over stale state when they disagree.
 11. In quick mode, generate missing artifacts in order, skip normal approval pauses, and continue into implementation in the same run.
-12. Without quick mode or explicit autonomy, stop after setup and ask whether to continue to research.
+12. **Without quick mode or explicit autonomy: STOP HERE after setup. Do NOT proceed to research. Wait for the user to explicitly ask to continue.** This is non-negotiable.
 
 ## Branch Isolation
 

--- a/plugins/ralph-specum-codex/skills/ralph-specum-tasks/SKILL.md
+++ b/plugins/ralph-specum-codex/skills/ralph-specum-tasks/SKILL.md
@@ -8,7 +8,7 @@ metadata:
 
 # Ralph Specum Tasks
 
-Use this for the tasks phase.
+You are a **coordinator, not a task planner** -- delegate ALL work to a `task-planner` sub-agent.
 
 ## Contract
 
@@ -24,15 +24,20 @@ Use this for the tasks phase.
 3. Clear any prior approval gate by merging `awaitingApproval: false` before generation.
 4. Respect `granularity` from state. Allow `--tasks-size fine|coarse` to override it. In quick mode, default unset granularity to `fine`.
 5. Use the current brainstorming interview style unless quick mode is active.
-6. Write or rewrite `tasks.md`.
-7. Count tasks and merge state with:
+6. **Delegate** task planning to a `task-planner` sub-agent. Pass requirements, design, research, and interview context. The sub-agent writes `tasks.md`. Do NOT write tasks.md yourself.
+7. Read the sub-agent's output and validate it exists.
+8. Count tasks and merge state with:
    - `phase: "tasks"`
    - `awaitingApproval: true`
    - `taskIndex: first incomplete or totalTasks`
    - `totalTasks: counted tasks`
 8. Update `.progress.md` with the phase breakdown, next milestone, blockers, next step, chosen granularity, and verification strategy.
-9. If spec commits are enabled, commit only the spec artifacts.
-10. In quick mode, review quickly, then continue directly into implementation.
+10. If spec commits are enabled, commit only the spec artifacts.
+
+### Stop Behavior
+
+- **Without `--quick`**: STOP HERE. Display the walkthrough summary and approval prompt. Do NOT continue to implementation. Wait for the user to explicitly approve and request the next phase.
+- **With `--quick`**: Review quickly, then continue directly into implementation.
 
 ## Output Shape
 

--- a/plugins/ralph-specum-codex/skills/ralph-specum-tasks/SKILL.md
+++ b/plugins/ralph-specum-codex/skills/ralph-specum-tasks/SKILL.md
@@ -28,10 +28,10 @@ You are a **coordinator, not a task planner** -- delegate ALL work to a `task-pl
 7. Read the sub-agent's output and validate it exists.
 8. Count tasks and merge state with:
    - `phase: "tasks"`
-   - `awaitingApproval: true`
+   - `awaitingApproval: true` (or `false` when `--quick` is active)
    - `taskIndex: first incomplete or totalTasks`
    - `totalTasks: counted tasks`
-8. Update `.progress.md` with the phase breakdown, next milestone, blockers, next step, chosen granularity, and verification strategy.
+9. Update `.progress.md` with the phase breakdown, next milestone, blockers, next step, chosen granularity, and verification strategy.
 10. If spec commits are enabled, commit only the spec artifacts.
 
 ### Stop Behavior

--- a/plugins/ralph-specum-codex/skills/ralph-specum-triage/SKILL.md
+++ b/plugins/ralph-specum-codex/skills/ralph-specum-triage/SKILL.md
@@ -26,8 +26,8 @@ You are a **coordinator, not a triage analyst** -- delegate decomposition work t
    - brainstorming and decomposition into specs
    - validation of dependencies, contracts, and scope
    - finalization of epic outputs
-   Do NOT decompose or build the epic yourself.
-4. Build `epic.md` from the sub-agent's output with:
+   Do NOT decompose or generate epic content yourself.
+4. Assemble `epic.md` by aggregating and formatting the sub-agent's output (without altering substantive content) into:
    - vision and scope
    - spec list with goals and size
    - dependency graph
@@ -43,6 +43,11 @@ The result should make it clear:
 - which specs can start now
 - which specs are blocked by dependencies
 - what contracts must stay stable across specs
+
+## Stop Behavior
+
+- **Without `--quick`**: STOP HERE. Display the epic summary and approval prompt. Do NOT continue to the next spec until the user explicitly approves or requests changes.
+- **With `--quick`**: Continue directly to the first unblocked spec.
 
 ## Response Handoff
 

--- a/plugins/ralph-specum-codex/skills/ralph-specum-triage/SKILL.md
+++ b/plugins/ralph-specum-codex/skills/ralph-specum-triage/SKILL.md
@@ -8,7 +8,7 @@ metadata:
 
 # Ralph Specum Triage
 
-Use this for large goals that should be decomposed into multiple dependency-aware specs.
+You are a **coordinator, not a triage analyst** -- delegate decomposition work to a `triage-analyst` sub-agent.
 
 ## Contract
 
@@ -21,12 +21,13 @@ Use this for large goals that should be decomposed into multiple dependency-awar
 
 1. Check `specs/.current-epic`. If an active epic exists, summarize status and offer resume, details, or a new epic.
 2. Resolve or create the epic directory and initialize `research.md`, `epic.md`, `.progress.md`, and `.epic-state.json` as needed.
-3. Run the current triage flow in four stages:
+3. **Delegate** triage work to a `triage-analyst` sub-agent. The sub-agent runs the four-stage triage flow:
    - exploration research on seams, constraints, and existing boundaries
    - brainstorming and decomposition into specs
    - validation of dependencies, contracts, and scope
    - finalization of epic outputs
-4. Build `epic.md` with:
+   Do NOT decompose or build the epic yourself.
+4. Build `epic.md` from the sub-agent's output with:
    - vision and scope
    - spec list with goals and size
    - dependency graph

--- a/plugins/ralph-specum-codex/skills/ralph-specum/SKILL.md
+++ b/plugins/ralph-specum-codex/skills/ralph-specum/SKILL.md
@@ -31,17 +31,17 @@ Handle these intents directly:
 | Intent | Action |
 |--------|--------|
 | Start, new, resume, quick mode | Follow the start flow in `references/workflow.md` |
-| Triage | Decompose a large goal into an epic and dependency-aware specs |
-| Research | Write `research.md` using the research template shape |
-| Requirements | Write `requirements.md` using the requirements template shape |
-| Design | Write `design.md` using the design template shape |
-| Tasks | Write `tasks.md` using the tasks template shape |
-| Implement | Run remaining tasks until completion or a blocker stops progress |
+| Triage | Delegate to `triage-analyst` sub-agent to decompose into epic and specs |
+| Research | Delegate to `research-analyst` sub-agent to write `research.md` |
+| Requirements | Delegate to `product-manager` sub-agent to write `requirements.md` |
+| Design | Delegate to `architect-reviewer` sub-agent to write `design.md` |
+| Tasks | Delegate to `task-planner` sub-agent to write `tasks.md` |
+| Implement | Delegate each task to `spec-executor` sub-agent until complete or blocked |
 | Status | Show active spec, backlog state, and per-root listing |
 | Switch | Update `.current-spec` only |
 | Cancel | Stop execution and clean up state, confirm before destructive delete |
 | Index | Generate `specs/.index/` component and external specs |
-| Refactor | Update existing spec files after implementation learnings |
+| Refactor | Delegate to `refactor-specialist` sub-agent to update spec files |
 | Feedback | Open or draft GitHub feedback |
 | Help | Summarize the surface and next commands |
 
@@ -49,6 +49,7 @@ If the corresponding helper skill is installed and the user invoked it explicitl
 
 ## Core Rules
 
+0. **You are a coordinator, not a doer.** For every phase (research, requirements, design, tasks, implement, triage, refactor), delegate the actual generation work to the appropriate sub-agent. Never write spec artifacts (research.md, requirements.md, design.md, tasks.md) yourself. Your job is to gather context, run the interview, delegate, validate the output, and present results for approval.
 1. Keep the Ralph disk contract stable.
 2. Treat `.claude/ralph-specum.local.md` as the settings source when present.
 3. Default to `./specs` when no valid config exists.
@@ -62,6 +63,16 @@ If the corresponding helper skill is installed and the user invoked it explicitl
 11. Use branch creation or worktree creation when the user asks for branch isolation or the repo policy requires it.
 12. Enter quick mode only when the user explicitly asks Ralph to be autonomous, do it quickly, or continue without pauses.
 13. In quick mode, generate missing artifacts, default task granularity to `fine` when unset, and continue into implementation in the same session.
+
+## Stop Enforcement
+
+After completing any phase artifact (research, requirements, design, tasks), you MUST:
+
+1. Display the walkthrough summary
+2. Present the approval prompt (approve / request changes / continue to next)
+3. **STOP and wait for user response**
+
+The ONLY exception is `--quick` mode. Without `--quick`, you MUST NOT auto-continue to the next phase. This is non-negotiable.
 
 ## Response Handoff
 


### PR DESCRIPTION
## Summary

- All 8 Codex phase skills now enforce coordinator-only behavior, delegating work to the appropriate sub-agent type (research-analyst, product-manager, architect-reviewer, task-planner, spec-executor, triage-analyst, refactor-specialist)
- Every phase skill stops after artifact generation and waits for user approval. Only `--quick` bypasses the stop gates
- Removed the "may execute inline" escape hatch from the parity matrix so Codex matches the Claude Code delegation model

## Files changed (12)

**Phase skills (7):** research, requirements, design, tasks, implement, triage, refactor -- added "coordinator, not a X" framing, delegation action steps, and Stop Behavior sections

**Primary/entry skills (2):** primary skill gets global delegation rule + routing table + Stop Enforcement section; start skill gets stronger stop enforcement

**References (2):** parity-matrix removes inline execution language; workflow adds Delegation Rules section and strengthens stop rules in Normal Flow

**Version (1):** bumped to v4.10.0

## Test plan

- [ ] Invoke `$ralph-specum-research` on a spec and confirm it delegates to a sub-agent instead of writing research.md inline
- [ ] Confirm agent stops after research and presents approval prompt (does not auto-continue to requirements)
- [ ] Invoke with `--quick` and confirm it auto-continues through phases
- [ ] Repeat for requirements, design, tasks phases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Coordinator now follows a delegation-first model: each phase delegates work to specialized sub-agents, validates outputs, and awaits results.

* **Behavior**
  * Enforced approval gates and stop behavior: after any phase artifact the system shows a walkthrough and halts for user approval unless quick mode is used.

* **Documentation**
  * Updated guidance with explicit phase→sub-agent mappings and coordinator constraints forbidding direct spec writing.

* **Chores**
  * Version bumped to 4.10.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->