### PR TITLE
feat(interview): use design-tree grilling by default

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "ralph-specum",
       "description": "Spec-driven development with research, requirements, design, tasks, autonomous execution, and epic triage. Fresh context per task.",
-      "version": "4.10.4",
+      "version": "4.10.5",
       "author": {
         "name": "tzachbon"
       },

--- a/plugins/ralph-specum-codex/.codex-plugin/plugin.json
+++ b/plugins/ralph-specum-codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ralph-specum",
-  "version": "4.10.4",
+  "version": "4.10.5",
   "description": "Spec-driven development for OpenAI Codex. Research, requirements, design, tasks, autonomous implementation, and epic triage for multi-spec feature decomposition.",
   "interface": {
     "displayName": "Ralph Specum"

--- a/plugins/ralph-specum/.claude-plugin/plugin.json
+++ b/plugins/ralph-specum/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ralph-specum",
-  "version": "4.10.4",
+  "version": "4.10.5",
   "description": "Spec-driven development with task-by-task execution. Research, requirements, design, tasks, autonomous implementation, and epic triage for multi-spec feature decomposition.",
   "author": {
     "name": "tzachbon"

--- a/plugins/ralph-specum/agents/task-planner.md
+++ b/plugins/ralph-specum/agents/task-planner.md
@@ -245,10 +245,10 @@ Before any Phase 1 tasks, insert:
 - `0.1 [VERIFY] Reproduce bug` -- run reproduction command, confirm it fails as described
 - `0.2 [VERIFY] Confirm repro is consistent` -- run reproduction command 3 times to confirm consistent failure
 
-Use reproduction command from (in priority order): bug interview Q5 response > `## Reality Check (BEFORE)` in .progress.md > project test runner from research.md.
+Use the reproduction command from (in priority order): the latest `Reproduction command:` entry in the goal grill > `## Reality Check (BEFORE)` in `.progress.md` > project test runner from `research.md`.
 
-**Rule 2: First [RED] task must reference BEFORE state.**
-The first [RED] task in Phase 1 must include a note referencing the reproduction command from `## Reality Check (BEFORE)` so the test locks in the exact failure mode documented before any code changes.
+**Rule 2: First [RED] task must reference the reproduced BEFORE state.**
+The first [RED] task in Phase 1 must include a note referencing the selected reproduction command and observed failure from `.progress.md` so the test locks in the exact failure mode documented before any code changes.
 
 **Rule 3: VF task is mandatory.**
 Always include a VF (Verification Final) task as the final task in Phase 4 regardless of other conditions. Do not omit it for BUG_FIX goals.
@@ -258,7 +258,7 @@ BUG_FIX intent always uses Bug TDD workflow (Phase 0 + TDD phases). Never use th
 
 **Rule 5: Reproduction command source priority.**
 When determining the reproduction command to use in Phase 0 tasks:
-1. Q5 interview response (from bug interview in .progress.md)
+1. Latest `Reproduction command:` entry from a Goal Grill round in `.progress.md`
 2. `## Reality Check (BEFORE)` block in .progress.md (`Reproduction command:` field)
 3. Project test runner from research.md (pnpm/npm/yarn test or equivalent)
 </mandatory>

--- a/plugins/ralph-specum/commands/design.md
+++ b/plugins/ralph-specum/commands/design.md
@@ -13,7 +13,7 @@ Generate technical design for the active spec. Running this command implicitly a
 Create a task for each item and complete in order:
 
 1. **Gather context** -- resolve spec, read requirements and research
-2. **Interview** -- brainstorming dialogue (skip if `--quick`)
+2. **Grill** -- resolve the design-tree frontier (skip if `--quick`)
 3. **Execute design** -- dispatch architect-reviewer via team
 4. **Artifact review** -- spec-reviewer validation loop (only if `--quick`)
 5. **Walkthrough & approval** -- display summary, get user approval
@@ -28,20 +28,15 @@ Create a task for each item and complete in order:
 5. Read `.ralph-state.json`; clear approval flag: `awaitingApproval: false`
 6. Read context: `requirements.md` (required), `research.md` (if exists), `.progress.md`
 
-## Step 2: Interview (skip if --quick)
+## Step 2: Grill (skip if --quick)
 
 Check if `--quick` appears in `$ARGUMENTS`. If present, skip to Step 3.
 
-### Read Context from .progress.md
+### Grilling
 
-Parse Intent Classification and all prior interview responses to skip already-answered questions.
+Apply `${CLAUDE_PLUGIN_ROOT}/skills/interview-framework/SKILL.md` in full. It owns context and spec-index reading, fact lookup, the design tree, frontier rounds, domain-language work, progress capture, and the shared-understanding confirmation gate.
 
-**Intent-Based Question Counts:**
-- TRIVIAL: 1-2 | REFACTOR: 3-5 | GREENFIELD: 5-10 | MID_SIZED: 3-7
-
-### Brainstorming Dialogue
-
-Apply adaptive dialogue from `${CLAUDE_PLUGIN_ROOT}/skills/interview-framework/SKILL.md`. Ask context-driven questions one at a time.
+Read intent classification and prior interview responses only as context for building the tree. Do not derive question counts from intent.
 
 **Design Exploration Territory** (hints, not a script):
 - **Architecture fit** -- extend existing architecture, create isolated module, or require refactor?
@@ -50,20 +45,21 @@ Apply adaptive dialogue from `${CLAUDE_PLUGIN_ROOT}/skills/interview-framework/S
 - **Failure modes** -- what failure scenarios matter? Graceful degradation, retry logic, alerting?
 - **Deployment model** -- feature flags, gradual rollout, migrations, or big-bang?
 
-### Design Approach Proposals
+### Architecture Approach Branch
 
-After dialogue, propose 2-3 architectural approaches. Examples (illustrative only):
+When architecture requires a user decision, add 2-3 grounded approaches to the design tree. Examples (illustrative only):
 - **(A)** Extend existing service/module layer -- minimal new abstractions
 - **(B)** New isolated component -- clean boundaries, own data layer
 - **(C)** Hybrid -- new module with shared infrastructure and data layer
 
-### Store Interview & Approach
+### Store Grill Results
 
 Append to `.progress.md` under "Interview Responses":
 ```markdown
-### Design Interview (from design.md)
-- [Topic 1]: [response]
+### Design Grill (from design.md)
+- [Round decisions and resolved facts]
 - Chosen approach: [name] -- [brief description]
+- Shared understanding: confirmed
 ```
 
 Pass combined context to delegation prompt as "Interview Context".

--- a/plugins/ralph-specum/commands/requirements.md
+++ b/plugins/ralph-specum/commands/requirements.md
@@ -13,7 +13,7 @@ Generate requirements for the active spec. Running this command implicitly appro
 Create a task for each item and complete in order:
 
 1. **Gather context** -- resolve spec, read research and goal
-2. **Interview** -- brainstorming dialogue (skip if `--quick`)
+2. **Grill** -- resolve the design-tree frontier (skip if `--quick`)
 3. **Execute requirements** -- dispatch product-manager via team
 4. **Artifact review** -- spec-reviewer validation loop (both modes)
 5. **Walkthrough & approval** -- display summary, get user approval
@@ -27,20 +27,15 @@ Create a task for each item and complete in order:
 4. Read `.ralph-state.json`; clear approval flag: `awaitingApproval: false`
 5. Read context: `research.md` (if exists), `.progress.md`, original goal
 
-## Step 2: Interview (skip if --quick)
+## Step 2: Grill (skip if --quick)
 
 Check if `--quick` appears in `$ARGUMENTS`. If present, skip to Step 3.
 
-### Read Context from .progress.md
+### Grilling
 
-Parse Intent Classification and prior interview responses to skip already-answered questions.
+Apply `${CLAUDE_PLUGIN_ROOT}/skills/interview-framework/SKILL.md` in full. It owns context and spec-index reading, fact lookup, the design tree, frontier rounds, domain-language work, progress capture, and the shared-understanding confirmation gate.
 
-**Intent-Based Question Counts:**
-- TRIVIAL: 1-2 | REFACTOR: 3-5 | GREENFIELD: 5-10 | MID_SIZED: 3-7
-
-### Brainstorming Dialogue
-
-Apply adaptive dialogue from `${CLAUDE_PLUGIN_ROOT}/skills/interview-framework/SKILL.md`. Ask context-driven questions one at a time.
+Read intent classification and prior interview responses only as context for building the tree. Do not derive question counts from intent.
 
 **Requirements Exploration Territory** (hints, not a script):
 - **Primary users** -- who will use this feature? Developers, end users, specific roles?
@@ -49,20 +44,21 @@ Apply adaptive dialogue from `${CLAUDE_PLUGIN_ROOT}/skills/interview-framework/S
 - **Scope boundaries** -- what is explicitly out of scope for this iteration?
 - **Compliance or regulatory needs** -- security, privacy, or regulatory considerations?
 
-### Requirements Approach Proposals
+### Scope Approach Branch
 
-After dialogue, propose 2-3 scoping approaches. Examples (illustrative only):
+When scope requires a user decision, add 2-3 grounded approaches to the design tree. Examples (illustrative only):
 - **(A)** Full feature set -- comprehensive user stories covering all use cases
 - **(B)** MVP scope -- core user stories only, defer edge cases to v2
 - **(C)** Phased delivery -- essential stories now, planned expansion later
 
-### Store Interview & Approach
+### Store Grill Results
 
 Append to `.progress.md` under "Interview Responses":
 ```markdown
-### Requirements Interview (from requirements.md)
-- [Topic 1]: [response]
+### Requirements Grill (from requirements.md)
+- [Round decisions and resolved facts]
 - Chosen approach: [name] -- [brief description]
+- Shared understanding: confirmed
 ```
 
 Pass combined context to delegation prompt as "Interview Context".

--- a/plugins/ralph-specum/commands/research.md
+++ b/plugins/ralph-specum/commands/research.md
@@ -13,7 +13,7 @@ Run parallel research for the active spec. You are a **coordinator, not a resear
 Create a task for each item and complete in order:
 
 1. **Gather context** -- resolve spec, read goal and existing files
-2. **Interview** -- brainstorming dialogue (skip if `--quick`)
+2. **Grill** -- resolve the design-tree frontier (skip if `--quick`)
 3. **Execute parallel research** -- dispatch team of research-analyst + Explore agents
 4. **Merge results** -- synthesize partial files into research.md
 5. **Artifact review** -- spec-reviewer validation loop (only if `--quick`)
@@ -28,22 +28,15 @@ Create a task for each item and complete in order:
 4. Read `.ralph-state.json` if it exists
 5. Read `.progress.md` to understand the goal
 
-## Step 2: Interview (skip if --quick)
+## Step 2: Grill (skip if --quick)
 
 Check if `--quick` appears in `$ARGUMENTS`. If present, skip to Step 3.
 
-### Read Context from .progress.md
+### Grilling
 
-Read `.progress.md` and parse:
-1. **Intent Classification** (TRIVIAL, REFACTOR, GREENFIELD, MID_SIZED) for question counts
-2. **Prior interview responses** to skip already-answered questions
+Apply `${CLAUDE_PLUGIN_ROOT}/skills/interview-framework/SKILL.md` in full. It owns context and spec-index reading, fact lookup, the design tree, frontier rounds, domain-language work, progress capture, and the shared-understanding confirmation gate.
 
-**Intent-Based Question Counts:**
-- TRIVIAL: 1-2 | REFACTOR: 3-5 | GREENFIELD: 5-10 | MID_SIZED: 3-7
-
-### Brainstorming Dialogue
-
-Apply adaptive dialogue from `${CLAUDE_PLUGIN_ROOT}/skills/interview-framework/SKILL.md`. Ask context-driven questions one at a time, adapting to prior answers.
+Read intent classification and prior interview responses only as context for building the tree. Do not derive question counts from intent.
 
 **Research Exploration Territory** (hints, not a script):
 - **Technical approach preference** -- follow existing patterns or introduce new ones?
@@ -52,20 +45,21 @@ Apply adaptive dialogue from `${CLAUDE_PLUGIN_ROOT}/skills/interview-framework/S
 - **Prior knowledge** -- what does the user already know vs what needs discovery?
 - **Technologies to evaluate or avoid** -- specific libraries, frameworks, or patterns
 
-### Research Approach Proposals
+### Research Strategy Branch
 
-After dialogue, propose 2-3 research strategies. Examples (illustrative only):
+When the research strategy requires a user decision, add 2-3 grounded strategies to the design tree. Examples (illustrative only):
 - **(A)** Deep dive on specific technology/library comparison
 - **(B)** Focus on existing codebase patterns with minimal external research
 - **(C)** Broad survey across multiple alternatives before narrowing
 
-### Store Interview & Approach
+### Store Grill Results
 
 Append to `.progress.md` under "Interview Responses":
 ```markdown
-### Research Interview (from research.md)
-- [Topic 1]: [response]
+### Research Grill (from research.md)
+- [Round decisions and resolved facts]
 - Chosen approach: [name] -- [brief description]
+- Shared understanding: confirmed
 ```
 
 Pass combined context to subagent delegation as "Interview Context".

--- a/plugins/ralph-specum/commands/start.md
+++ b/plugins/ralph-specum/commands/start.md
@@ -85,9 +85,11 @@ Read `${CLAUDE_PLUGIN_ROOT}/references/spec-scanner.md` and follow the scanning 
 
 <mandatory>
 **Skip spec scanner and index hint if --quick flag detected in $ARGUMENTS.**
+
+If no goal is available yet, set `scannerDeferred: true` in command context and defer this step. Do not run keyword matching against an empty goal. New Flow runs the scanner immediately after collecting the goal.
 </mandatory>
 
-**Summary**: Scans ./specs/ directory (and all configured specs_dirs) for related specs using keyword matching. Displays related specs with relevance scores. Shows index hint if codebase indexing not yet done. Stores relatedSpecs in .ralph-state.json for use during interview.
+**Summary**: Scans all configured spec directories for related specs using keyword matching. Displays related specs with relevance scores and shows an index hint when needed. Carries the results into New Flow, which persists them after `.ralph-state.json` exists.
 
 ## Step 3.5: Epic Detection
 
@@ -160,9 +162,19 @@ Continuing...
 
 1. If no name provided, ask: "What should we call this spec?" (validates kebab-case)
 2. If no goal provided, ask: "What is the goal? Describe what you want to build."
-3. Determine spec directory:
+2a. If `scannerDeferred` is true, run **Scan Existing Specs** now with the collected goal and retain its `RELATED_SPECS` result.
+3. Resolve the spec directory before creating files:
    ```text
-   specsDir = (--specs-dir if valid) OR (interview response) OR ralph_get_default_dir()
+   if --specs-dir is present:
+     validate it against ralph_get_specs_dirs()
+     specsDir = validated value
+   else if ralph_get_specs_dirs() returns more than one directory:
+     ask "Where should this spec be stored?"
+     recommend ralph_get_default_dir() first and list each configured directory
+     specsDir = user choice
+   else:
+     specsDir = ralph_get_default_dir()
+
    basePath = "$specsDir/$name"
    ```
 4. Create spec directory: `mkdir -p "$basePath"`
@@ -175,10 +187,11 @@ Continuing...
      "phase": "research", "taskIndex": 0, "totalTasks": 0,
      "taskIteration": 1, "maxTaskIterations": 5,
      "globalIteration": 1, "maxGlobalIterations": 100,
-     "commitSpec": true, "quickMode": false,
+     "commitSpec": true, "quickMode": false, "relatedSpecs": [],
      "discoveredSkills": []
    }
    ```
+   Replace the empty `relatedSpecs` array with the results carried from **Scan Existing Specs**. If the scanner found no matches, keep the empty array.
    If this spec was suggested by an active epic, also include:
    ```json
    "epicName": "$EPIC_NAME"
@@ -222,7 +235,7 @@ Continuing...
       ```
       If no skills match: `- No skills matched`
 10. Update Spec Index: `./plugins/ralph-specum/hooks/scripts/update-spec-index.sh --quiet`
-11. **Goal Interview** -- Read `${CLAUDE_PLUGIN_ROOT}/references/goal-interview.md` and follow brainstorming dialogue
+11. **Goal Grill** -- Read `${CLAUDE_PLUGIN_ROOT}/references/goal-interview.md` and resolve its design-tree frontier before research
 12. **Team Research Phase** -- Read `${CLAUDE_PLUGIN_ROOT}/references/parallel-research.md` and follow the dispatch pattern
 13. **Skill Discovery Pass 2 (Post-Research Retry)** -- Re-scan skills with enriched context after research completes:
 

--- a/plugins/ralph-specum/commands/tasks.md
+++ b/plugins/ralph-specum/commands/tasks.md
@@ -13,7 +13,7 @@ Generate implementation tasks for the active spec. Running this command implicit
 Create a task for each item and complete in order:
 
 1. **Gather context** -- resolve spec, read design, requirements, research
-2. **Interview** -- brainstorming dialogue (skip if `--quick`)
+2. **Grill** -- resolve the design-tree frontier (skip if `--quick`)
 3. **Execute task generation** -- dispatch task-planner via team
 4. **Artifact review** -- spec-reviewer validation loop (only if `--quick`)
 5. **Walkthrough & approval** -- display summary, get user approval
@@ -34,20 +34,15 @@ Create a task for each item and complete in order:
 8. **Quick mode granularity default**: If `--quick` is present in `$ARGUMENTS` AND `granularity` is not set in `.ralph-state.json`, set `"granularity": "fine"` in `.ralph-state.json`
 9. Read context: `requirements.md`, `design.md`, `research.md` (if exists), `.progress.md`
 
-## Step 2: Interview (skip if --quick)
+## Step 2: Grill (skip if --quick)
 
 Check if `--quick` appears in `$ARGUMENTS`. If present, skip to Step 3.
 
-### Read Context from .progress.md
+### Grilling
 
-Parse Intent Classification and all prior interview responses to skip already-answered questions.
+Apply `${CLAUDE_PLUGIN_ROOT}/skills/interview-framework/SKILL.md` in full. It owns context and spec-index reading, fact lookup, the design tree, frontier rounds, domain-language work, progress capture, and the shared-understanding confirmation gate.
 
-**Intent-Based Question Counts:**
-- TRIVIAL: 1-2 | REFACTOR: 3-5 | GREENFIELD: 5-10 | MID_SIZED: 3-7
-
-### Brainstorming Dialogue
-
-Apply adaptive dialogue from `${CLAUDE_PLUGIN_ROOT}/skills/interview-framework/SKILL.md`. Ask context-driven questions one at a time.
+Read intent classification and prior interview responses only as context for building the tree. Do not derive question counts from intent.
 
 **Tasks Exploration Territory** (hints, not a script):
 - **Testing thoroughness** -- minimal POC-only tests, standard unit + integration, or comprehensive E2E?
@@ -68,21 +63,22 @@ If either condition is false, skip the granularity question:
 
 When the user answers the granularity question, store the response in `.progress.md` under Interview Responses and update `"granularity"` in `.ralph-state.json`.
 
-### Tasks Approach Proposals
+### Execution Strategy Branch
 
-After dialogue, propose 2-3 execution strategies. Examples (illustrative only):
+When execution strategy requires a user decision, add 2-3 grounded strategies to the design tree. Examples (illustrative only):
 - **(A)** Aggressive POC -- fewer tasks, ship in small increments, add polish later
 - **(B)** Thorough -- more tasks with full test coverage and quality gates throughout
 - **(C)** Phased delivery -- split into multiple PRs with clear milestones
 
-### Store Interview & Approach
+### Store Grill Results
 
 Append to `.progress.md` under "Interview Responses":
 ```markdown
-### Tasks Interview (from tasks.md)
-- [Topic 1]: [response]
+### Tasks Grill (from tasks.md)
+- [Round decisions and resolved facts]
 - E2E verification: YES/NO -- [strategy or "auto"]
 - Chosen approach: [name] -- [brief description]
+- Shared understanding: confirmed
 ```
 
 Pass combined context to delegation prompt as "Interview Context".

--- a/plugins/ralph-specum/references/goal-interview.md
+++ b/plugins/ralph-specum/references/goal-interview.md
@@ -1,104 +1,81 @@
-# Goal Interview
+# Goal Grill
 
 > Used by: start.md
 
-This reference contains the pre-research brainstorming dialogue conducted in normal mode (skipped in --quick mode). It uses intent classification from `intent-classification.md` to calibrate depth.
+This reference defines the pre-research grill in normal mode. Quick mode skips it.
 
-## Prerequisites
+## Prerequisite
 
-- Intent classification must be completed first (see `intent-classification.md` for Goal Intent Classification)
-- Dialogue depth determined by intent type (TRIVIAL: 1-2, REFACTOR: 3-5, GREENFIELD: 5-10, MID_SIZED: 3-7)
+Classify intent first using `intent-classification.md`. Use intent to seed relevant design-tree branches, not to set a question count.
 
-## Bug Interview (BUG_FIX Intent)
+## Run the Grill
 
-When intent is `BUG_FIX`, replace the standard brainstorming dialogue with these focused questions:
+Apply `${CLAUDE_PLUGIN_ROOT}/skills/interview-framework/SKILL.md` in full.
 
-1. Walk me through the exact steps to reproduce this bug. What do you do, in what order?
-2. What did you expect to happen? What actually happened instead?
-3. When did this start? Was it working before? (if yes: what changed?)
-4. Is there an existing failing test that captures this bug, or do we need to write one?
-5. What is the fastest command to reproduce the failure? (e.g., `pnpm test -- --grep 'login'`, `curl localhost:3000/api/users`). If none, describe the manual steps.
-
-### After Bug Interview
-
-Skip approach proposals and Spec Location Interview. Store all responses in `## Interview Responses` as usual.
-
-## Brainstorming Dialogue
-
-Apply adaptive dialogue from `${CLAUDE_PLUGIN_ROOT}/skills/interview-framework/SKILL.md`.
-
-The coordinator asks context-driven questions one at a time based on the exploration territory below and what's already known from the goal text. Questions adapt to prior answers. After enough understanding, propose approaches.
+The framework reads prior artifacts, the specification index, relevant domain context, and repository facts before it asks the user for decisions. It asks the whole user-decision frontier in numbered rounds and does not start research until the user confirms shared understanding.
 
 ## Goal Exploration Territory
 
-Areas to probe during the UNDERSTAND phase (hints, not a script -- generate actual questions from these based on context):
+Use these areas to seed the design tree. Add or remove branches as the evidence and answers require:
 
-- **Problem being solved** -- what pain point or need is driving this goal?
-- **Constraints and must-haves** -- performance, compatibility, timeline, integration requirements
-- **Success criteria** -- how will the user know this feature works correctly?
-- **Scope boundaries** -- what's explicitly in and out of scope?
-- **User's existing knowledge** -- what does the user already know about the problem space vs what needs discovery?
+- **Problem** - pain point or need behind the goal
+- **Constraints** - performance, compatibility, timeline, integration, or policy boundaries
+- **Success** - observable behavior or evidence that proves the work succeeded
+- **Scope** - explicit inclusions, exclusions, and deferred branches
+- **Existing system** - related indexed specs, domain concepts, code paths, and reusable behavior
+- **Approach** - viable implementation shapes and their trade-offs
 
-## Goal Approach Proposals
+## Bug-Fix Territory
 
-After the dialogue, propose 2-3 high-level approaches tailored to the user's goal. Examples (illustrative only -- approaches should be specific, not generic):
+For `BUG_FIX`, seed the tree with the causal chain instead of using a fixed questionnaire:
 
-- **(A)** Extend existing system/module to support the new capability
-- **(B)** Build a new standalone module with clean boundaries
-- **(C)** Lightweight integration using existing primitives with minimal new code
+- reproduction steps and smallest failing command
+- expected behavior and observed behavior
+- regression point or relevant change history
+- existing failing test or missing reproducer
+- affected scope and required behavior preservation
+- evidence that will prove the fix
 
-## Spec Location Interview
+Resolve repository facts through tests, code, configuration, logs, and git history. Ask the user only for experience or decisions that the repository cannot provide.
 
-After the standard goal interview questions, determine where the spec should be stored:
+## Resolved Spec Location
 
-```text
-Spec Location Logic:
-
-1. Check if --specs-dir already provided -> SKIP
-2. Get configured directories: dirs = ralph_get_specs_dirs()
-3. If dirs.length > 1: ASK using AskUserQuestion "Where should this spec be stored?"
-4. If dirs.length == 1: OUTPUT awareness message (non-blocking):
-   "Spec will be created in ./specs/
-    Tip: You can organize specs in multiple directories.
-    See /ralph-specum:help for multi-directory setup."
-5. Store specsDir for use in spec creation
-```
+`start.md` resolves spec location before creating the spec directory. Read that location as settled context and do not ask for it again during the goal grill.
 
 ## Store Goal Context
 
-After interview and approach selection, update `.progress.md`:
+The interview framework appends each round to `.progress.md`. Keep intent metadata compact:
 
 ```markdown
 ## Interview Format
-- Version: 1.0
+- Version: 2.0
 
 ## Intent Classification
-- Type: [TRIVIAL|REFACTOR|GREENFIELD|MID_SIZED]
+- Type: [BUG_FIX|TRIVIAL|REFACTOR|GREENFIELD|MID_SIZED]
 - Confidence: [high|medium|low] ([N] keywords matched)
-- Min questions: [N]
-- Max questions: [N]
 - Keywords matched: [list of matched keywords]
 
 ## Interview Responses
 
-### Goal Interview (from start.md)
-- [Topic 1]: [response]
-- [Topic 2]: [response]
+### Goal Grill - Round 1
+- Facts resolved: [fact and evidence]
+- Decisions: [topic] -> [answer]
+- Reproduction command: [exact command or manual steps, for BUG_FIX]
+- Frontier after round: [remaining decisions or empty]
+
+### Goal Grill - Confirmed
+- Shared understanding: confirmed
 - Chosen approach: [name] -- [one-line rationale]
-- Spec location: [responses.specsDir] (if multi-dir was asked)
-[Any follow-up responses from "Other" selections]
+- Spec location: [resolved directory]
 ```
 
 ## Pass Context to Research Team
 
-Include goal interview context in each research teammate's task description:
+Include the confirmed goal-grill context in each research task:
 
 ```text
-Each TaskCreate description should include:
+Goal Grill Context:
+[Include resolved facts, decisions, scope exclusions, domain language, and chosen approach from .progress.md]
 
-Goal Interview Context:
-[Include all topic-response pairs from the Goal Interview section of .progress.md]
-Chosen Approach: [name]
-
-Use this context to focus research on relevant areas.
+Use this context to focus research. Do not reopen confirmed user decisions unless new evidence contradicts them.
 ```

--- a/plugins/ralph-specum/references/intent-classification.md
+++ b/plugins/ralph-specum/references/intent-classification.md
@@ -145,11 +145,11 @@ Examples:
 
 ## Goal Intent Classification
 
-Before asking interview questions, classify the user's goal to determine question depth.
+Before grilling, classify the user's goal to seed the design tree with the right territory. Intent changes which branches receive attention; it never sets a question count or completion threshold.
 
 ### Classification Logic
 
-Analyze the goal text for keywords to determine intent type:
+Analyze the goal text for keywords:
 
 ```text
 Intent Classification:
@@ -158,33 +158,35 @@ Intent Classification:
    - "fix", "resolve", "debug", "broken", "failing"
    - "not working", "error", "bug", "patch", "crash"
    - "regression", "reproduce", "repro", "issue"
-   -> Min questions: 5, Max questions: 5
-   Note: TRIVIAL-specific keywords (typo, spelling, minor, tiny, rename, update text) override BUG_FIX when both match.
+   -> Seed reproduction, expected versus observed behavior, regression history,
+      affected scope, and verification branches.
+   Note: TRIVIAL-specific keywords override BUG_FIX when both match.
 
 2. TRIVIAL: Goal contains keywords like:
    - "fix typo", "typo", "spelling"
-   - "small change", "minor"
-   - "quick", "simple", "tiny"
+   - "small change", "minor", "quick", "simple", "tiny"
    - "rename", "update text"
-   -> Min questions: 1, Max questions: 2
+   -> Seed target, exact desired result, and scope-boundary branches.
 
 3. REFACTOR: Goal contains keywords like:
    - "refactor", "restructure", "reorganize"
    - "clean up", "cleanup", "simplify"
    - "extract", "consolidate", "modularize"
    - "improve code", "tech debt"
-   -> Min questions: 3, Max questions: 5
+   -> Seed behavior preservation, boundaries, migration risk, and verification branches.
 
 4. GREENFIELD: Goal contains keywords like:
    - "new feature", "new system", "new module"
    - "add", "build", "implement", "create"
-   - "integrate", "introduce"
-   - "from scratch"
-   -> Min questions: 5, Max questions: 10
+   - "integrate", "introduce", "from scratch"
+   -> Seed users, problem, domain language, scope, constraints, integration,
+      approach, failure behavior, and verification branches.
 
 5. MID_SIZED: Default if no clear match
-   -> Min questions: 3, Max questions: 7
+   -> Seed goal, scope, constraints, integration, approach, and verification branches.
 ```
+
+The interview framework expands or removes branches from repository facts and user answers. It ends only when the frontier is empty and the user confirms shared understanding.
 
 ### Confidence Threshold
 
@@ -194,38 +196,17 @@ Intent Classification:
 | 1-2 keywords | Medium | Use matched category |
 | 0 keywords | Low | Default to MID_SIZED |
 
-### Question Count Rules
-
-- BUG_FIX: 5 questions (understand reproduction, scope, and root cause)
-- TRIVIAL: 1-2 questions (get essentials, move fast)
-- REFACTOR: 3-5 questions (understand scope and risks)
-- GREENFIELD: 5-10 questions (full context needed)
-- MID_SIZED: 3-7 questions (balanced approach)
-
-### Dialogue Depth by Intent
-
-Intent classification determines how deep the brainstorming dialogue goes:
-
-| Intent | Min Questions | Max Questions |
-|--------|---------------|---------------|
-| BUG_FIX | 5 | 5 |
-| TRIVIAL | 1 | 2 |
-| REFACTOR | 3 | 5 |
-| GREENFIELD | 5 | 10 |
-| MID_SIZED | 3 | 7 |
-
 ### Store Intent
 
 After classification, store the result in `.progress.md`:
+
 ```markdown
 ## Interview Format
-- Version: 1.0
+- Version: 2.0
 
 ## Intent Classification
 - Type: [BUG_FIX|TRIVIAL|REFACTOR|GREENFIELD|MID_SIZED]
 - Confidence: [high|medium|low] ([N] keywords matched)
-- Min questions: [N]
-- Max questions: [N]
 - Keywords matched: [list of matched keywords]
 ```
 

--- a/plugins/ralph-specum/references/spec-scanner.md
+++ b/plugins/ralph-specum/references/spec-scanner.md
@@ -16,6 +16,13 @@ ralph_list_specs()        # List all specs as "name|path" pairs
 ralph_resolve_current()   # Resolve .current-spec to full path
 ```
 
+Resolve index paths once:
+
+```text
+defaultDir = ralph_get_default_dir()
+indexDir = "$defaultDir/.index"
+```
+
 ## Scanning Steps
 
 ```text
@@ -25,9 +32,9 @@ ralph_resolve_current()   # Resolve .current-spec to full path
    - Exclude the current spec being created (if known)
    - Exclude .index directory (handled separately in step 1b)
    |
-1b. Scan indexed specs (if ./specs/.index/ exists):
-   - List component specs: ls ./specs/.index/components/*.md 2>/dev/null
-   - List external specs: ls ./specs/.index/external/*.md 2>/dev/null
+1b. Scan indexed specs (if $indexDir exists):
+   - List component specs: ls "$indexDir"/components/*.md 2>/dev/null
+   - List external specs: ls "$indexDir"/external/*.md 2>/dev/null
    - For each indexed spec:
      - Read the file and extract "## Purpose" section (component) or "## Summary" section (external)
      - Use the purpose/summary as the match text
@@ -59,24 +66,27 @@ ralph_resolve_current()   # Resolve .current-spec to full path
    - spec-name-1 [High]: [first 50 chars of Original Goal]... [dir-path if non-default]
    - spec-name-2 [Medium]: [first 50 chars of Original Goal]... [dir-path if non-default]
 
-   Indexed components (from specs/.index/components):
+   Indexed components (from $indexDir/components):
    - auth-controller [High]: Handles authentication and session management...
    - user-service [Medium]: User CRUD operations and validation...
 
-   Indexed external (from specs/.index/external):
+   Indexed external (from $indexDir/external):
    - api-docs [Low]: External API documentation for...
    |
-   This context may inform the interview questions.
+   This context becomes evidence for the grill's design tree.
    |
-6. Store in state file:
-   - Update .ralph-state.json with relatedSpecs array:
+6. Return and persist results:
+   - Keep the ranked array in command context as RELATED_SPECS.
+   - If the target .ralph-state.json already exists, merge the relatedSpecs array into it.
+   - If state does not exist yet, do not create it here. The New Flow writes RELATED_SPECS into the initial state after creating the spec directory.
+   - Use this array shape:
      {
        ...existing state,
        "relatedSpecs": [
          {"name": "spec-name-1", "path": "full/path", "goal": "Original Goal text", "score": N, "type": "feature", "relevance": "High"},
          {"name": "spec-name-2", "path": "full/path", "goal": "Original Goal text", "score": N, "type": "feature", "relevance": "Medium"},
-         {"name": "auth-controller", "path": "specs/.index/components", "goal": "Purpose text", "score": N, "type": "indexed-component", "relevance": "High"},
-         {"name": "api-docs", "path": "specs/.index/external", "goal": "Summary text", "score": N, "type": "indexed-external", "relevance": "Low"}
+         {"name": "auth-controller", "path": "$indexDir/components", "goal": "Purpose text", "score": N, "type": "indexed-component", "relevance": "High"},
+         {"name": "api-docs", "path": "$indexDir/external", "goal": "Summary text", "score": N, "type": "indexed-external", "relevance": "Low"}
        ]
      }
 ```
@@ -122,18 +132,16 @@ Related specs found:
 - api-refactor: Restructure API endpoints for better...
 - error-handling: Implement consistent error handling...
 
-This context may inform the interview questions.
+This context becomes evidence for the grill's design tree.
 ```
 
-## Usage in Interview
+## Usage in the Grill
 
-After scanning, if related specs were found, reference them when asking clarifying questions:
-- "I noticed you have a spec 'user-auth' for authentication. Does this new feature relate to or depend on that work?"
-- "There's an existing 'api-refactor' spec. Should this work integrate with those changes?"
+After scanning, read relevant matches as facts before building the design tree. Use them to expose decisions without asking the user to repeat discoverable information:
+- "The indexed `auth-controller` owns authentication. Should this feature extend that boundary or establish a separate one?"
+- "The `api-refactor` spec changes these endpoints. Should this work depend on that spec or remain independently deliverable?"
 
-For indexed specs, reference them to understand existing codebase patterns:
-- "The indexed auth-controller component handles authentication. Should this feature extend that controller or create a new one?"
-- "I found an indexed external spec for your API documentation. Does this feature need to follow the patterns described there?"
+Put independent decisions on the same frontier round. Keep a decision blocked when it depends on an unresolved spec or code fact.
 
 ## Spec Directory Validation
 
@@ -250,35 +258,6 @@ Validation Sequence:
    - Display: "Created '$name-2' at $specsDir ($name already exists)"
 ```
 
-## Spec Location Interview
-
-After the standard goal interview questions, determine where the spec should be stored:
-
-```text
-Spec Location Logic:
-
-1. Check if --specs-dir already provided in $ARGUMENTS
-   -> SKIP spec location question entirely, use provided value
-
-2. Get configured directories: dirs = ralph_get_specs_dirs()
-
-3. If dirs.length > 1 (multiple directories configured):
-   -> ASK using AskUserQuestion:
-     Question: "Where should this spec be stored?"
-     Options: [each configured directory as an option]
-   -> Store response as specsDir
-
-4. If dirs.length == 1 (only default directory):
-   -> OUTPUT awareness message (non-blocking, just inform):
-     "Spec will be created in ./specs/
-      Tip: You can organize specs in multiple directories.
-      See /ralph-specum:help for multi-directory setup."
-   -> Use default directory as specsDir
-   -> Continue immediately without waiting for response
-
-5. Store specsDir for use in spec creation
-```
-
 ## Index Hint
 
 Before starting a new spec, check if codebase indexing exists (skip if --quick):
@@ -286,8 +265,10 @@ Before starting a new spec, check if codebase indexing exists (skip if --quick):
 ```bash
 # Session guard (skip if already shown in this session)
 if [ -z "${RALPH_SPECUM_INDEX_HINT_SHOWN:-}" ]; then
-  # Check if specs/.index/ exists and has content
-  if [ ! -d "./specs/.index" ] || [ -z "$(ls -A ./specs/.index 2>/dev/null)" ]; then
+  defaultDir="$(ralph_get_default_dir)"
+  indexDir="$defaultDir/.index"
+  # Check if the configured default index exists and has content
+  if [ ! -d "$indexDir" ] || [ -z "$(ls -A "$indexDir" 2>/dev/null)" ]; then
     SHOW_INDEX_HINT=true
   else
     SHOW_INDEX_HINT=false

--- a/plugins/ralph-specum/skills/interview-framework/SKILL.md
+++ b/plugins/ralph-specum/skills/interview-framework/SKILL.md
@@ -1,104 +1,121 @@
 ---
 name: interview-framework
-description: This skill should be used when running an interactive interview before a spec phase, gathering requirements through dialogue, asking the user clarifying questions before delegating to a subagent, or when any Ralph phase command (research, requirements, design, tasks) needs adaptive brainstorming dialogue. Covers the 3-phase algorithm (Understand, Propose Approaches, Confirm and Store).
-version: 0.2.0
+description: This skill should be used when running any normal-mode interview before a spec phase, grilling the user to reach shared understanding, gathering requirements through dialogue, or resolving design decisions before delegating to a Ralph subagent. Covers fact-first discovery, design-tree frontier rounds, recommendations, domain language, and confirmation.
+version: 0.3.0
 user-invocable: false
 ---
 
 # Interview Framework
 
-Adaptive brainstorming dialogue algorithm for all spec phases. Each phase command provides its own exploration territory (phase-specific areas to probe).
+Treat every normal-mode interview governed by this framework as a grill. Reach shared understanding before delegating research, requirements, design, or task planning.
 
-## Option Limit Rule
+Quick mode skips the interview. Do not weaken normal-mode grilling to imitate quick mode.
 
-Each question must have 2-4 options (max 4). Keep the most relevant options, combine similar ones.
+## Completion Contract
 
-## Recommendation Format
+Do not proceed because the conversation feels sufficient or a question count has been reached. Proceed only when:
 
-Every question asked via `AskUserQuestion` in Phase 1 leads with the recommended option (except when options are symmetric, in which case `[Recommended]` may be omitted):
+1. All discoverable facts required by the design tree have been resolved.
+2. The design-tree frontier is empty.
+3. Every branch is resolved or the user has explicitly placed it out of scope.
+4. The user confirms the resulting shared understanding.
 
-```yaml
-AskUserQuestion:
-  question: "[Context-aware question referencing prior answers]. [One sentence rationale for the recommendation.]"
-  options:
-    - "[Recommended] [Option text -- the AI's suggested answer]"
-    - "[Alternative 1]"
-    - "[Alternative 2 if needed]"
-    - "Other"
-```
+## Preflight: Find Facts Before Questions
 
-Rules:
-- `[Recommended]` is a label prefix on the first option only.
-- The rationale sits in the question text, not the option label.
-- Option count still 2-4 max (Option Limit Rule preserved).
-- If there is no meaningful recommendation (truly symmetric choice), omit the `[Recommended]` label rather than placing it arbitrarily.
+Read the available project context before building the design tree:
 
-Example:
+1. Read the original goal, `.progress.md`, `.ralph-state.json`, and prior phase artifacts.
+2. Resolve the default specs directory with `ralph_get_default_dir()` when available, otherwise use `./specs`. Read `<default-specs-dir>/.index/index.md` when it exists, then open only relevant indexed entries and related specs.
+3. Read `CONTEXT-MAP.md` when it exists and follow it to the applicable `CONTEXT.md`. Otherwise read the root `CONTEXT.md` when present.
+4. Inspect code, configuration, tests, and existing specs for any fact needed by the interview.
 
-```yaml
-AskUserQuestion:
-  question: "Where should the spec live? You only have one specs directory configured, so the default is fine unless you want to reorganize."
-  options:
-    - "[Recommended] ./specs/ (default)"
-    - "Let me configure a different path"
-    - "Other"
-```
+Classify every unknown:
 
-## Codebase-First Exploration
+- **Fact**: discoverable from the repository, tools, documentation, or existing artifacts. Resolve it with Explore or another read-only subagent. Never ask the user.
+- **Decision**: a preference, priority, trade-off, boundary, or constraint that only the user can settle. Put it on the design tree.
 
-Before asking any question, determine whether the answer is a **codebase fact** or a **user decision**:
+Run independent fact lookups in parallel. A pending lookup blocks only the decisions that depend on it; ask the rest of the current frontier.
 
-- **Codebase fact**: something discoverable by reading code, config, or existing specs (e.g., which framework is used, whether an interface already exists, what a file currently does). Use the Explore agent to find it. Never ask the user.
-- **User decision**: a preference, priority, trade-off, or constraint that only the user can answer (e.g., which approach to take, what the success criteria are, what's in scope). Ask via AskUserQuestion.
+## Build the Design Tree
 
-Only ask what you cannot discover yourself.
+Map every decision as a node. Add dependency edges from foundational decisions to the decisions that require them.
 
-## Completion Signal Detection
+Track each node as one of:
 
-After each response, check for early completion signals using token-based matching:
+- `OPEN`: ready once its prerequisites resolve
+- `INVESTIGATING`: waiting on a fact lookup
+- `RESOLVED`: answered by evidence, the user, or a justified inference
+- `OUT_OF_SCOPE`: explicitly excluded by the user
+
+Define the **frontier** as every open decision whose prerequisites are resolved. Do not ask a decision that depends on another decision still open in the same round.
+
+Use the calling command's exploration territory as a starting point, then add branches exposed by project context, prior answers, concrete scenarios, and code contradictions. Do not use fixed question counts or a canned questionnaire.
+
+## Grill in Frontier Rounds
+
+Ask the whole current frontier in one round:
+
+1. Number each question (`Q1`, `Q2`, and so on).
+2. Ground it in known facts and prior answers.
+3. Give a recommended answer with a short rationale.
+4. Provide 2-4 meaningful options, with the recommendation first and `Other` last.
+5. Omit the recommendation label only when the options are symmetric.
+
+Use `AskUserQuestion` for the round when the tool is available. Put the whole frontier in one call when it fits. If the frontier exceeds the tool limit, use multiple calls for that same round and wait for every frontier answer. If `AskUserQuestion` is unavailable, render the same numbered round in the response and wait for the user's answers. Advance the tree only after the user answers the round.
+
+Format each question as:
 
 ```text
-completionSignals = ["done", "proceed", "skip", "enough", "that's all", "continue", "next"]
+Q1 - <short title>: <context-aware decision question>
 
-tokens = tokenize(userResponse.lower())  # split on whitespace/punctuation
-for signal in completionSignals:
-  if signal in tokens:  # exact token match, not substring
-    -> SKIP remaining questions, move to PROPOSE APPROACHES
+Recommendation: <recommended answer and rationale>
 ```
 
-## 3-Phase Overview
+After the user answers the round:
 
-### Phase 1: UNDERSTAND (Decision-Tree)
+1. Mark answered nodes resolved.
+2. Record any justified inferences.
+3. Add branches exposed by the answers.
+4. Turn an `Other` response into a specific dependent question for the next frontier. Never ask a generic follow-up.
+5. Recompute the frontier and start the next round.
 
-Read all available context (.progress.md, prior artifacts, goal text). Build a question tree from the exploration territory with dependency ordering. Traverse the tree: auto-resolve codebase facts via exploration, ask user only about decisions. Each question leads with `[Recommended]` answer. No fixed question caps. Exit when all nodes resolved or user signals completion.
+Treat `done`, `skip`, or similar language as a request to narrow scope, not as an automatic exit. Show the remaining branches and require explicit confirmation before marking them out of scope.
 
-See `references/algorithm.md` for full pseudocode.
+## Model Domain Language During the Grill
 
-### Phase 2: PROPOSE APPROACHES
+Apply `references/domain-modeling.md` throughout the rounds.
 
-Synthesize dialogue into 2-3 distinct approaches. Each includes: name, description, trade-offs. Lead with recommendation. Present via AskUserQuestion. Maximum 3 approaches (more causes decision fatigue). Trade-offs must be honest. No straw-man alternatives.
+- Challenge terms that conflict with `CONTEXT.md`.
+- Replace fuzzy or overloaded words with a proposed canonical term.
+- Use concrete boundary and edge-case scenarios to test the model.
+- Check claims about current behavior against code.
+- Update the applicable `CONTEXT.md` as soon as a domain term is resolved. Do not batch glossary work until the end.
 
-See `references/algorithm.md` for full pseudocode.
+Keep implementation details and technical decisions out of `CONTEXT.md`. This interview framework does not create ADRs; `design.md` remains the specification's technical-decision record.
 
-### Phase 3: CONFIRM & STORE
+## Store Progress After Every Round
 
-Brief recap to user of key decisions and chosen approach. If user corrects something, update before storing. Store in .progress.md under Context Accumulator pattern.
+Append each completed round to `.progress.md` under `## Interview Responses`. Record facts, decisions, explicit scope exclusions, and any glossary updates. Preserve earlier rounds.
 
-See `references/algorithm.md` for full pseudocode.
+```markdown
+### <Phase> Grill - Round <N>
+- Facts resolved: <fact and evidence>
+- Decisions: <topic> -> <answer>
+- Out of scope: <explicitly excluded branch, if any>
+- Domain language: <canonical term and definition, if any>
+- Frontier after round: <remaining unblocked decisions or empty>
+```
 
-## Adaptive Depth (Other Responses)
+Do not store a parallel interview mode or question counter in `.ralph-state.json`.
 
-When user selects "Other": ask a context-specific follow-up (never generic "elaborate"). Reference what the user typed. Continue until clarity or 5 rounds. Do not increment askedCount for follow-ups.
+## Confirm Shared Understanding
 
-See `references/examples.md` for example follow-up patterns.
+When the frontier becomes empty, present a compact summary of settled decisions, scope boundaries, and the chosen approach. Ask the user to confirm it.
 
-## Context Accumulator Pattern
-
-After each interview, update `.progress.md`: read existing content, append new section under "## Interview Responses" with descriptive keys reflecting what was discussed. Include the chosen approach.
-
-See `references/examples.md` for storage format.
+If the user corrects or extends the summary, reopen the affected branch and continue grilling. Delegate to the phase agent only after confirmation.
 
 ## References
 
-- **`references/algorithm.md`** -- Full 3-phase pseudocode (UNDERSTAND decision-tree, PROPOSE APPROACHES, CONFIRM & STORE)
-- **`references/examples.md`** -- Example interview questions, "Other" response handling, context storage format
+- **`references/algorithm.md`** - Full fact-first design-tree and frontier-round algorithm
+- **`references/domain-modeling.md`** - `CONTEXT.md` discovery, language challenges, scenarios, and inline glossary updates
+- **`references/examples.md`** - Frontier-round and progress-storage examples

--- a/plugins/ralph-specum/skills/interview-framework/references/algorithm.md
+++ b/plugins/ralph-specum/skills/interview-framework/references/algorithm.md
@@ -1,128 +1,92 @@
-# Interview Algorithm (3-Phase)
+# Grilling Algorithm
 
-Detailed pseudocode for the adaptive brainstorming dialogue algorithm.
-
-## Phase 1: UNDERSTAND (Decision-Tree)
+Use this algorithm for every normal-mode Ralph interview.
 
 ```text
-UNDERSTAND:
-  1. Read all available context:
-     - .progress.md (prior phase answers, intent, goal)
-     - Prior artifacts (research.md, requirements.md, etc.)
-     - Original goal text
-  2. Read the exploration territory provided by the calling command
-  3. Identify what is UNKNOWN vs what is already decided
-     - If prior phases already covered a topic, mark it RESOLVED. Skip it.
-  4. Build the question tree:
-     nodes = []
-     for each area in exploration_territory:
-       nodes.append({ topic: area, status: OPEN, dependency: [], finding: null })
-     # Dependency ordering: if topic B requires knowing topic A first,
-     # set B.dependency = [A]. Do not ask B until A is RESOLVED.
+GRILL:
+  1. GATHER CONTEXT
+     - Read the original goal, .progress.md, .ralph-state.json, and prior artifacts.
+     - Read <default-specs-dir>/.index/index.md when present.
+     - Open related indexed entries and existing specs that may affect the goal.
+     - Read CONTEXT-MAP.md and its applicable CONTEXT.md, or root CONTEXT.md.
+     - Read the calling command's exploration territory.
 
-  DECISION-TREE TRAVERSAL:
-    while any node.status == OPEN:
-      # Select next node: first OPEN node whose dependencies are all RESOLVED
-      node = next_unblocked_open_node(nodes)
-      if node is null: break  # All remaining nodes are blocked (shouldn't happen)
+  2. BUILD DESIGN TREE
+     nodes = decisions implied by:
+       - the goal and phase territory
+       - prior artifacts and interview rounds
+       - spec-index relationships
+       - domain-language conflicts
+       - concrete scenarios and edge cases
+       - contradictions between user claims and code
 
-      # Codebase-first check
-      if node.topic is a codebase FACT (not a user decision):
-        finding = explore_codebase(node.topic)
-        node.status = RESOLVED
-        node.finding = finding
-        log: "Discovered: [topic] -> [finding]"
-        continue
+     for each node:
+       classify unknowns as FACT or USER_DECISION
+       record prerequisite decision and fact dependencies
+       set status = OPEN, INVESTIGATING, RESOLVED, or OUT_OF_SCOPE
 
-      # Ask user
-      recommended = derive_recommendation(node.topic, context, prior_answers)
-      AskUserQuestion:
-        question: "[Context-aware question]. [Recommended: recommended.rationale]"
-        options:
-          - "[Recommended] [recommended.option]"
-          - "[Alternative 1]"
-          - "[Alternative 2 if needed]"
-          - "Other"
+  3. RESOLVE FACTS
+     fact_frontier = discoverable facts whose prerequisites are resolved
+     dispatch independent fact_frontier lookups in parallel
+     mark each lookup INVESTIGATING
+     on result:
+       record evidence
+       mark fact RESOLVED
+       update dependent nodes
 
-      node.status = RESOLVED
-      node.finding = user_answer
+  4. ASK USER FRONTIER
+     user_frontier = every OPEN user decision whose prerequisites are RESOLVED
 
-      # Resolve any dependent nodes that this answer makes obvious
-      for dep_node in nodes where node in dep_node.dependency:
-        if dep_node can be inferred from node.finding:
-          dep_node.status = RESOLVED
-          dep_node.finding = inferred_value
-          log: "Inferred: [dep_topic] -> [inferred_value]"
+     if user_frontier is not empty:
+       build one numbered round from the whole frontier
+       for each question:
+         ground it in facts and prior answers
+         derive a recommended answer and rationale
+         present 2-4 meaningful options with recommendation first and Other last
+       if AskUserQuestion is available:
+         submit the round through AskUserQuestion
+       else:
+         render the same numbered round in the response
+       wait for every answer in the round
 
-      # Completion signal check
-      if user_answer contains completion_signal:
-        break
+       for each answer:
+         mark the node RESOLVED
+         infer dependent answers only when the inference is justified
+         add newly exposed branches
+         challenge glossary conflicts or fuzzy terms
+         test domain boundaries with concrete scenarios where needed
+         update CONTEXT.md immediately when a domain term resolves
 
-    -> Move to PROPOSE APPROACHES
+       append the round to .progress.md
+       return to RESOLVE FACTS
+
+  5. HANDLE APPARENT STOP SIGNALS
+     if the user asks to stop while unresolved branches remain:
+       show the remaining branches
+       ask whether each branch is out of scope or still needs resolution
+       mark OUT_OF_SCOPE only after explicit confirmation
+       return to RESOLVE FACTS
+
+  6. COMPLETE
+     if any fact is INVESTIGATING:
+       wait for it and return to RESOLVE FACTS
+     if any decision is OPEN:
+       return to ASK USER FRONTIER
+     if every branch is RESOLVED or OUT_OF_SCOPE:
+       summarize decisions, scope, approach, and domain-language updates
+       ask the user to confirm shared understanding
+       if corrected:
+         reopen affected nodes and return to RESOLVE FACTS
+       if confirmed:
+         store final summary in .progress.md
+         delegate to the phase agent
 ```
 
-**Key rules for question generation:**
-- Each question builds on prior answers in THIS dialogue AND prior phases
-- Reference specific things the user said ("You mentioned X, does that mean...")
-- Never ask something .progress.md already answers
-- Never ask generic questions. Every question must be grounded in the user's context.
-- If you have enough context to propose meaningful approaches, stop and move on. Do not exhaust every open node mechanically.
+## Invariants
 
-## Phase 2: PROPOSE APPROACHES
-
-```text
-PROPOSE APPROACHES:
-  1. Synthesize the dialogue into 2-3 distinct approaches
-  2. Each approach MUST include:
-     - Name (short label)
-     - Description (1-2 sentences)
-     - Trade-offs (pros and cons)
-  3. Lead with your recommendation
-  4. Present via AskUserQuestion:
-
-  AskUserQuestion:
-    question: "Based on our discussion, here are the approaches I see:
-
-      **A) [Recommended] [Name]**
-      [Description]. Trade-off: [pro] vs [con].
-
-      **B) [Name]**
-      [Description]. Trade-off: [pro] vs [con].
-
-      **C) [Name]** (if applicable)
-      [Description]. Trade-off: [pro] vs [con].
-
-      Which approach fits best?"
-    options:
-      - "A) [Name]"
-      - "B) [Name]"
-      - "C) [Name]" (if applicable)
-      - "Other"
-
-  5. If user picks "Other":
-     -> Ask what they'd change or combine
-     -> Iterate until approach is confirmed (max 3 rounds)
-  6. Store chosen approach as primary input for the subagent
-```
-
-**Approach rules:**
-- Always present at least 2 approaches (never just 1)
-- Maximum 3 approaches (more causes decision fatigue)
-- The recommended approach goes first
-- Trade-offs must be honest. No straw-man alternatives.
-- Apply YAGNI: strip unnecessary complexity from all approaches
-
-## Phase 3: CONFIRM & STORE
-
-```text
-CONFIRM & STORE:
-  1. Brief recap to the user:
-     "Here's what I'll pass to the [agent name]:
-      - [Key decision 1]
-      - [Key decision 2]
-      - [Chosen approach summary]
-      Does this look right?"
-  2. If user corrects something, update before storing
-  3. Store in .progress.md (see Context Accumulator in SKILL.md)
-  4. Proceed to subagent delegation
-```
+- Ask no repository fact as a user question.
+- Ask no dependent decision before its prerequisites resolve.
+- Ask every currently unblocked user decision in the same round.
+- Add no fixed question cap or early-exit heuristic.
+- Advance no phase with an open frontier.
+- Create no interview mode or counter in `.ralph-state.json`.

--- a/plugins/ralph-specum/skills/interview-framework/references/domain-modeling.md
+++ b/plugins/ralph-specum/skills/interview-framework/references/domain-modeling.md
@@ -1,0 +1,47 @@
+# Domain Modeling During Grilling
+
+Use domain modeling to sharpen project language while the design tree is active.
+
+## Locate the Applicable Context
+
+1. Resolve the repository root.
+2. If `CONTEXT-MAP.md` exists, read it and select the context that owns the current capability. If the mapped `CONTEXT.md` does not exist, create it at that mapped path only when the first term for that context is resolved.
+3. Otherwise read the root `CONTEXT.md` when present.
+4. If neither file exists, create a root `CONTEXT.md` only when the first project-specific domain term becomes resolved. Never fall back to the root when `CONTEXT-MAP.md` names the owning context. Do not create an empty placeholder during preflight.
+5. If multiple contexts could own the term and repository evidence cannot decide, add context ownership to the user-decision frontier.
+
+## Work the Language
+
+- Challenge a term that conflicts with the glossary in the same round.
+- Replace vague or overloaded words with a proposed canonical term.
+- Invent a concrete scenario when a relationship, boundary, lifecycle, or ownership rule remains fuzzy.
+- Read the relevant code when the user describes current behavior. Surface any contradiction as evidence for the next frontier.
+- Keep general programming terms out of the domain glossary.
+
+## Update CONTEXT.md Inline
+
+Write a resolved term during the round that resolves it. Do not wait until the interview ends.
+
+Use this format:
+
+```markdown
+# <Context Name>
+
+<One or two sentences describing the context.>
+
+## Language
+
+**<Canonical Term>**:
+<One or two sentences defining what the concept is.>
+_Avoid_: <conflicting or discouraged alternatives>
+```
+
+Apply these rules:
+
+- Pick one canonical term.
+- Define what the concept is, not how code implements it.
+- Keep definitions to one or two sentences.
+- List competing names under `_Avoid_` when doing so prevents future ambiguity.
+- Preserve unrelated glossary entries and existing context structure.
+
+Do not store requirements, implementation details, task notes, or technical decisions in `CONTEXT.md`. Do not create ADRs from the interview framework; keep technical decisions in the spec's `design.md`.

--- a/plugins/ralph-specum/skills/interview-framework/references/examples.md
+++ b/plugins/ralph-specum/skills/interview-framework/references/examples.md
@@ -1,58 +1,68 @@
-# Interview Examples
+# Grilling Examples
 
-Example interview questions, "Other" response handling, and context storage patterns.
+## One Frontier Round
 
-## Adaptive Depth -- "Other" Response Examples
-
-Follow-up questions must be context-specific, not generic. When a user provides an "Other" response:
-
-1. **Acknowledge the specific response** -- Reference what the user actually typed
-2. **Ask a probing question based on response content** -- Analyze keywords in their response
-3. **Include context from prior answers** -- Reference earlier responses to create continuity
-
-Do NOT use generic follow-ups like "Can you elaborate?" -- always tailor to their specific response.
-
-### GraphQL Example
-
-If user types "We need GraphQL support" for a technical approach question:
-
-```yaml
-AskUserQuestion:
-  question: "You mentioned needing GraphQL support. Is this for the entire API layer, or specific endpoints only?"
-  options:
-    - "Full API layer - replace REST"
-    - "Hybrid - GraphQL for new endpoints only"
-    - "Specific queries for mobile clients"
-    - "Other"
-```
-
-### Security Example
-
-If user types "Security is critical" for success criteria:
-
-```yaml
-AskUserQuestion:
-  question: "You emphasized security is critical. Given your earlier constraints, which security aspects matter most?"
-  options:
-    - "Authentication and authorization"
-    - "Data encryption at rest and in transit"
-    - "Audit logging and compliance"
-    - "Other"
-```
-
-## Context Accumulator -- Storage Format
-
-After each interview, update `.progress.md`:
-
-1. Read existing .progress.md content
-2. Append new section under "## Interview Responses"
-3. Use descriptive keys that reflect what was actually discussed
-4. Include the chosen approach
+Assume repository exploration has established that the project uses REST, has no background worker, and already exposes an authenticated admin API. Two independent user decisions are now unblocked.
 
 ```text
-### [Phase] Interview (from [phase].md)
-- [Topic 1]: [response]
-- [Topic 2]: [response]
-- Chosen approach: [name] -- [brief description]
-[Any follow-up responses from "Other" selections]
+Q1 - Delivery boundary: Should the first version run inside the existing admin API or introduce a worker?
+
+Recommendation: Keep it in the admin API. The repository has no worker infrastructure, and the current workload does not justify adding one.
+
+Options:
+- [Recommended] Extend the admin API
+- Introduce a background worker
+- Other
+
+Q2 - First-release scope: Should the first version process one item or support batches?
+
+Recommendation: Start with one item. This proves the workflow without committing to batch failure semantics.
+
+Options:
+- [Recommended] One item per request
+- Batch processing
+- Other
+```
+
+Ask both questions in the same round because neither depends on the other. A retry-policy question belongs to a later round because it depends on the delivery-boundary answer.
+
+Submit this round through `AskUserQuestion` when available. Otherwise render the block in the response and wait for both answers.
+
+## Fact Lookup While a Round Continues
+
+If deployment support requires a code lookup, mark that branch `INVESTIGATING`. Continue the round with unrelated scope and user-experience decisions. Ask deployment decisions only after the lookup returns.
+
+## Domain-Language Challenge
+
+If `CONTEXT.md` defines **Workspace** as a tenant boundary and the user says "account" while describing tenant ownership, ask:
+
+```text
+Q3 - Canonical owner term: Do you mean the existing Workspace concept, or a separate user Account?
+
+Recommendation: Use Workspace if the boundary matches the glossary and code. This avoids introducing two names for the same domain concept.
+```
+
+After confirmation, update `CONTEXT.md` in that round.
+
+## Progress Storage
+
+```markdown
+## Interview Responses
+
+### Design Grill - Round 1
+- Facts resolved: Existing admin API at `src/admin`; no worker runtime configured
+- Decisions: Delivery boundary -> extend admin API
+- Decisions: First-release scope -> one item per request
+- Domain language: Workspace -> tenant boundary that owns the operation
+- Frontier after round: failure behavior, retry policy
+
+### Design Grill - Round 2
+- Decisions: Failure behavior -> return the existing problem-details response
+- Decisions: Retry policy -> caller retries; service adds no retry queue
+- Out of scope: batch partial-failure semantics
+- Frontier after round: empty
+
+### Design Grill - Confirmed
+- Shared understanding confirmed by user
+- Chosen approach: extend the existing admin API for single-item processing
 ```

--- a/plugins/ralph-specum/skills/spec-workflow/SKILL.md
+++ b/plugins/ralph-specum/skills/spec-workflow/SKILL.md
@@ -78,7 +78,7 @@ specs/
 ### Guided development
 ```bash
 /ralph-specum:start my-feature "Build X"
-# Interactive interviews at each phase
+# Fact-first grilling at each phase
 # Review and approve each artifact
 /ralph-specum:implement
 ```

--- a/tests/interview-framework.bats
+++ b/tests/interview-framework.bats
@@ -1,71 +1,134 @@
 #!/usr/bin/env bats
 # Interview Framework Content Tests
-# Verifies SKILL.md contains required algorithm sections and patterns.
+# Verifies that normal interviews use the fact-first grilling contract.
 
 SKILL_FILE="plugins/ralph-specum/skills/interview-framework/SKILL.md"
 ALGORITHM_FILE="plugins/ralph-specum/skills/interview-framework/references/algorithm.md"
-GOAL_INTERVIEW="plugins/ralph-specum/references/goal-interview.md"
+EXAMPLES_FILE="plugins/ralph-specum/skills/interview-framework/references/examples.md"
+DOMAIN_FILE="plugins/ralph-specum/skills/interview-framework/references/domain-modeling.md"
+GOAL_GRILL="plugins/ralph-specum/references/goal-interview.md"
+INTENT_FILE="plugins/ralph-specum/references/intent-classification.md"
+START_COMMAND="plugins/ralph-specum/commands/start.md"
+SPEC_SCANNER="plugins/ralph-specum/references/spec-scanner.md"
+TASK_PLANNER="plugins/ralph-specum/agents/task-planner.md"
+PHASE_COMMANDS=(
+    "plugins/ralph-specum/commands/research.md"
+    "plugins/ralph-specum/commands/requirements.md"
+    "plugins/ralph-specum/commands/design.md"
+    "plugins/ralph-specum/commands/tasks.md"
+)
 
-@test "SKILL.md exists" {
+@test "grilling framework and references exist" {
     [ -f "$SKILL_FILE" ]
+    [ -f "$ALGORITHM_FILE" ]
+    [ -f "$EXAMPLES_FILE" ]
+    [ -f "$DOMAIN_FILE" ]
 }
 
-@test "SKILL.md has Codebase-First Exploration section" {
-    grep -q "## Codebase-First Exploration" "$SKILL_FILE"
+@test "normal interview is the grill without an opt-in mode" {
+    grep -q "Treat every normal-mode interview governed by this framework as a grill" "$SKILL_FILE"
+    grep -q "Quick mode skips the interview" "$SKILL_FILE"
+    ! grep -Eq '(interviewMode|grillMode)' "$SKILL_FILE" "$ALGORITHM_FILE" "$GOAL_GRILL" "${PHASE_COMMANDS[@]}"
 }
 
-@test "SKILL.md codebase-first section distinguishes facts from decisions" {
-    grep -q "Codebase fact" "$SKILL_FILE"
-    grep -q "User decision" "$SKILL_FILE"
+@test "preflight reads the specification index and domain context" {
+    grep -q '\.index/index\.md' "$SKILL_FILE"
+    grep -q 'CONTEXT-MAP\.md' "$SKILL_FILE"
+    grep -q 'CONTEXT\.md' "$SKILL_FILE"
+    grep -q 'relevant indexed entries' "$SKILL_FILE"
+    grep -q 'Goal Grill' "$START_COMMAND"
+    grep -q "evidence for the grill's design tree" "$SPEC_SCANNER"
+    grep -q 'defaultDir = ralph_get_default_dir()' "$SPEC_SCANNER"
+    grep -q 'indexDir = "$defaultDir/.index"' "$SPEC_SCANNER"
 }
 
-@test "interview-framework has decision-tree traversal (not WHILE loop)" {
-    # SKILL.md references decision-tree in heading
-    grep -q "Decision-Tree" "$SKILL_FILE"
-    # Full pseudocode in algorithm.md
-    grep -q "DECISION-TREE TRAVERSAL" "$ALGORITHM_FILE"
-    # WHILE loop should be gone from both
-    ! grep -q "WHILE askedCount" "$SKILL_FILE"
-    ! grep -q "WHILE askedCount" "$ALGORITHM_FILE"
+@test "start resolves location and persists scanner results before the grill" {
+    grep -q "If no goal is available yet" "$START_COMMAND"
+    grep -q "Do not run keyword matching against an empty goal" "$START_COMMAND"
+    grep -q 'If `scannerDeferred` is true' "$START_COMMAND"
+    grep -q "Resolve the spec directory before creating files" "$START_COMMAND"
+    grep -q "Carries the results into New Flow" "$START_COMMAND"
+    grep -q 'do not create it here' "$SPEC_SCANNER"
+    grep -q 'writes RELATED_SPECS into the initial state' "$SPEC_SCANNER"
+    grep -q "do not ask for it again during the goal grill" "$GOAL_GRILL"
 }
 
-@test "SKILL.md has [Recommended] label pattern" {
-    grep -q "\[Recommended\]" "$SKILL_FILE"
+@test "framework separates discoverable facts from user decisions" {
+    grep -q '\*\*Fact\*\*' "$SKILL_FILE"
+    grep -q '\*\*Decision\*\*' "$SKILL_FILE"
+    grep -q "Ask no repository fact as a user question" "$ALGORITHM_FILE"
 }
 
-@test "SKILL.md completion signal check has no minRequired guard" {
-    ! grep -q "askedCount >= minRequired" "$SKILL_FILE"
+@test "framework asks the whole design-tree frontier in numbered rounds" {
+    grep -q "Build the Design Tree" "$SKILL_FILE"
+    grep -q "Ask the whole current frontier in one round" "$SKILL_FILE"
+    grep -q 'Number each question (`Q1`, `Q2`' "$SKILL_FILE"
+    grep -q "Ask every currently unblocked user decision in the same round" "$ALGORITHM_FILE"
 }
 
-@test "SKILL.md has no Intent-Based Depth Scaling table" {
-    ! grep -q "Intent-Based Depth Scaling" "$SKILL_FILE"
+@test "frontier rounds prefer AskUserQuestion and retain a text fallback" {
+    grep -q 'Use `AskUserQuestion` for the round when the tool is available' "$SKILL_FILE"
+    grep -q 'If `AskUserQuestion` is unavailable' "$SKILL_FILE"
+    grep -q 'if AskUserQuestion is available' "$ALGORITHM_FILE"
+    grep -q 'render the same numbered round in the response' "$ALGORITHM_FILE"
 }
 
-@test "SKILL.md preserves Option Limit Rule" {
-    grep -q "Option Limit Rule" "$SKILL_FILE"
+@test "each decision includes a grounded recommendation and bounded options" {
+    grep -q "Give a recommended answer with a short rationale" "$SKILL_FILE"
+    grep -q 'Provide 2-4 meaningful options' "$SKILL_FILE"
+    grep -q '\[Recommended\]' "$EXAMPLES_FILE"
 }
 
-@test "SKILL.md preserves Phase 2 PROPOSE APPROACHES" {
-    grep -q "PROPOSE APPROACHES" "$SKILL_FILE"
+@test "completion requires an empty frontier and shared-understanding confirmation" {
+    grep -q "design-tree frontier is empty" "$SKILL_FILE"
+    grep -q "user confirms the resulting shared understanding" "$SKILL_FILE"
+    grep -q "Advance no phase with an open frontier" "$ALGORITHM_FILE"
 }
 
-@test "SKILL.md preserves Phase 3 CONFIRM & STORE" {
-    grep -q "CONFIRM & STORE" "$SKILL_FILE"
+@test "domain modeling challenges language and updates context inline" {
+    grep -q "Challenge a term that conflicts with the glossary" "$DOMAIN_FILE"
+    grep -q "vague or overloaded words" "$DOMAIN_FILE"
+    grep -q "concrete scenario" "$DOMAIN_FILE"
+    grep -q "Read the relevant code" "$DOMAIN_FILE"
+    grep -q "create it at that mapped path only when the first term" "$DOMAIN_FILE"
+    grep -q "create a root.*only when the first project-specific domain term" "$DOMAIN_FILE"
+    grep -q "Never fall back to the root" "$DOMAIN_FILE"
+    grep -q "Write a resolved term during the round that resolves it" "$DOMAIN_FILE"
 }
 
-@test "goal-interview.md does not contain duplicate codebase-first mandatory block" {
-    ! grep -q "is this a codebase fact or a user decision" "$GOAL_INTERVIEW"
+@test "grilling does not create ADRs" {
+    grep -q "does not create ADRs" "$SKILL_FILE"
+    grep -q "Do not create ADRs" "$DOMAIN_FILE"
+    grep -q '`design\.md` remains' "$SKILL_FILE"
+    ! grep -Eq 'ADR-FORMAT|docs/adr' "$SKILL_FILE" "$DOMAIN_FILE"
 }
 
-@test "goal-interview.md still references SKILL.md for adaptive dialogue" {
-    grep -q "skills/interview-framework/SKILL.md" "$GOAL_INTERVIEW"
+@test "goal and phase interviews all apply the grilling framework" {
+    grep -q "skills/interview-framework/SKILL.md" "$GOAL_GRILL"
+
+    for command in "${PHASE_COMMANDS[@]}"; do
+        grep -q "skills/interview-framework/SKILL.md" "$command"
+        grep -q "resolve the design-tree frontier" "$command"
+    done
 }
 
-@test "plugin.json version is 4.10.4" {
-    grep -q '"version": "4.10.4"' "plugins/ralph-specum/.claude-plugin/plugin.json"
+@test "fixed question counts and one-at-a-time traversal are absent" {
+    files=("$SKILL_FILE" "$ALGORITHM_FILE" "$GOAL_GRILL" "$INTENT_FILE" "${PHASE_COMMANDS[@]}")
+
+    ! grep -Eq 'TRIVIAL: [0-9]+-[0-9]+|GREENFIELD: [0-9]+-[0-9]+|Min questions:|Max questions:' "${files[@]}"
+    ! grep -Eiq 'questions? one at a time|WHILE askedCount|askedCount >= minRequired|maxAllowed' "${files[@]}"
 }
 
-@test "marketplace.json ralph-specum version is 4.10.4" {
-    version=$(jq -r '.plugins[] | select(.name == "ralph-specum") | .version' ".claude-plugin/marketplace.json")
-    [ "$version" = "4.10.4" ]
+@test "bug task planning reads the goal grill reproduction command" {
+    grep -q 'latest `Reproduction command:` entry in the goal grill' "$TASK_PLANNER"
+    grep -q 'Goal Grill round' "$TASK_PLANNER"
+    ! grep -Eq 'Q5|bug interview' "$TASK_PLANNER"
+}
+
+@test "plugin and marketplace versions match" {
+    plugin_version=$(jq -r '.version' "plugins/ralph-specum/.claude-plugin/plugin.json")
+    marketplace_version=$(jq -r '.plugins[] | select(.name == "ralph-specum") | .version' ".claude-plugin/marketplace.json")
+
+    [[ "$plugin_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
+    [ "$plugin_version" = "$marketplace_version" ]
 }


### PR DESCRIPTION
## Summary

Normal spec-phase interviews now use fact-first design-tree grilling. The framework reads the spec index and domain context before asking for user decisions, and it prefers AskUserQuestion when available.

The interview updates CONTEXT.md for settled domain terms, keeps technical decisions in design.md, and does not create ADRs.

## Tests

- bats tests/*.bats
- bash tests/helpers/version-sync.sh
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced fact-first “Grill” workflows for goals, requirements, research, design, and tasks.
  * Added structured decision rounds with recommendations, grounded options, shared-understanding confirmation, and progress tracking.
  * Improved project terminology clarification and context updates during planning.
  * Enhanced startup handling for quick mode, deferred scanning, and specification directory selection.
  * Bug-fix planning now uses recorded reproduction commands and observed failures.

* **Documentation**
  * Updated workflow guidance and examples to reflect the new grilling process.

* **Chores**
  * Updated the plugin version to 4.10.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->