### PR TITLE
fix(phase-gate): support versioned plugin cache roots

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "ralph-specum",
       "description": "Spec-driven development with research, requirements, design, tasks, autonomous execution, and epic triage. Fresh context per task.",
-      "version": "4.12.0",
+      "version": "4.12.1",
       "author": {
         "name": "tzachbon"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "ralph-specum",
       "description": "Spec-driven development with research, requirements, design, tasks, autonomous execution, and epic triage. Fresh context per task.",
-      "version": "4.12.1",
+      "version": "4.12.2",
       "author": {
         "name": "tzachbon"
       },

--- a/plugins/ralph-specum-codex/.codex-plugin/plugin.json
+++ b/plugins/ralph-specum-codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ralph-specum",
-  "version": "4.12.0",
+  "version": "4.12.1",
   "description": "Spec-driven development for OpenAI Codex. Research, requirements, design, tasks, autonomous implementation, and epic triage for multi-spec feature decomposition.",
   "interface": {
     "displayName": "Ralph Specum"

--- a/plugins/ralph-specum-codex/.codex-plugin/plugin.json
+++ b/plugins/ralph-specum-codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ralph-specum",
-  "version": "4.12.1",
+  "version": "4.12.2",
   "description": "Spec-driven development for OpenAI Codex. Research, requirements, design, tasks, autonomous implementation, and epic triage for multi-spec feature decomposition.",
   "interface": {
     "displayName": "Ralph Specum"

--- a/plugins/ralph-specum-codex/scripts/phase_gate.py
+++ b/plugins/ralph-specum-codex/scripts/phase_gate.py
@@ -294,6 +294,10 @@ def validate_discovery_linkage(
 
 
 def packaged_core_contract() -> tuple[str, Path, tuple[Path, ...]]:
+    """Return `(core name, source, resources)`.
+
+    Unknown roots require exactly one known packaged core.
+    """
     plugin_root = Path(__file__).resolve().parent.parent
     package_key = plugin_root.name
     if package_key not in PACKAGED_CORES:

--- a/plugins/ralph-specum-codex/scripts/phase_gate.py
+++ b/plugins/ralph-specum-codex/scripts/phase_gate.py
@@ -295,11 +295,19 @@ def validate_discovery_linkage(
 
 def packaged_core_contract() -> tuple[str, Path, tuple[Path, ...]]:
     plugin_root = Path(__file__).resolve().parent.parent
-    skill_name = PACKAGED_CORES.get(plugin_root.name)
-    if skill_name is None:
-        fail("UNRECOGNIZED_PLUGIN_ROOT", "phase gate helper is outside a recognized packaged plugin root")
+    package_key = plugin_root.name
+    if package_key not in PACKAGED_CORES:
+        matching_package_keys = [
+            candidate_key
+            for candidate_key, candidate_skill_name in PACKAGED_CORES.items()
+            if (plugin_root / "skills" / candidate_skill_name / "SKILL.md").is_file()
+        ]
+        if len(matching_package_keys) != 1:
+            fail("UNRECOGNIZED_PLUGIN_ROOT", "phase gate helper is outside a recognized packaged plugin root")
+        package_key = matching_package_keys[0]
+    skill_name = PACKAGED_CORES[package_key]
     skill_source = plugin_root / "skills" / skill_name / "SKILL.md"
-    resource_names = PACKAGED_CORE_RESOURCES[plugin_root.name]
+    resource_names = PACKAGED_CORE_RESOURCES[package_key]
     resource_sources = tuple(
         (plugin_root / "skills" / skill_name / "references" / resource_name).resolve()
         for resource_name in resource_names

--- a/plugins/ralph-specum/.claude-plugin/plugin.json
+++ b/plugins/ralph-specum/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ralph-specum",
-  "version": "4.12.1",
+  "version": "4.12.2",
   "description": "Spec-driven development with task-by-task execution. Research, requirements, design, tasks, autonomous implementation, and epic triage for multi-spec feature decomposition.",
   "author": {
     "name": "tzachbon"

--- a/plugins/ralph-specum/.claude-plugin/plugin.json
+++ b/plugins/ralph-specum/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ralph-specum",
-  "version": "4.12.0",
+  "version": "4.12.1",
   "description": "Spec-driven development with task-by-task execution. Research, requirements, design, tasks, autonomous implementation, and epic triage for multi-spec feature decomposition.",
   "author": {
     "name": "tzachbon"

--- a/plugins/ralph-specum/scripts/phase_gate.py
+++ b/plugins/ralph-specum/scripts/phase_gate.py
@@ -294,6 +294,10 @@ def validate_discovery_linkage(
 
 
 def packaged_core_contract() -> tuple[str, Path, tuple[Path, ...]]:
+    """Return `(core name, source, resources)`.
+
+    Unknown roots require exactly one known packaged core.
+    """
     plugin_root = Path(__file__).resolve().parent.parent
     package_key = plugin_root.name
     if package_key not in PACKAGED_CORES:

--- a/plugins/ralph-specum/scripts/phase_gate.py
+++ b/plugins/ralph-specum/scripts/phase_gate.py
@@ -295,11 +295,19 @@ def validate_discovery_linkage(
 
 def packaged_core_contract() -> tuple[str, Path, tuple[Path, ...]]:
     plugin_root = Path(__file__).resolve().parent.parent
-    skill_name = PACKAGED_CORES.get(plugin_root.name)
-    if skill_name is None:
-        fail("UNRECOGNIZED_PLUGIN_ROOT", "phase gate helper is outside a recognized packaged plugin root")
+    package_key = plugin_root.name
+    if package_key not in PACKAGED_CORES:
+        matching_package_keys = [
+            candidate_key
+            for candidate_key, candidate_skill_name in PACKAGED_CORES.items()
+            if (plugin_root / "skills" / candidate_skill_name / "SKILL.md").is_file()
+        ]
+        if len(matching_package_keys) != 1:
+            fail("UNRECOGNIZED_PLUGIN_ROOT", "phase gate helper is outside a recognized packaged plugin root")
+        package_key = matching_package_keys[0]
+    skill_name = PACKAGED_CORES[package_key]
     skill_source = plugin_root / "skills" / skill_name / "SKILL.md"
-    resource_names = PACKAGED_CORE_RESOURCES[plugin_root.name]
+    resource_names = PACKAGED_CORE_RESOURCES[package_key]
     resource_sources = tuple(
         (plugin_root / "skills" / skill_name / "references" / resource_name).resolve()
         for resource_name in resource_names

--- a/specs/fix-versioned-plugin-cache-phase-gate/design.md
+++ b/specs/fix-versioned-plugin-cache-phase-gate/design.md
@@ -1,0 +1,65 @@
+---
+spec: fix-versioned-plugin-cache-phase-gate
+phase: design
+created: 2026-08-31
+---
+
+# Design: Versioned Plugin-Cache Phase Gate
+
+## Approach
+
+Fix the shared root-cause resolver, `packaged_core_contract()`, in both shipped `phase_gate.py` copies. Keep its current direct package-name lookup. Only when `plugin_root.name` is unknown, inspect `plugin_root / "skills" / <known-core> / "SKILL.md"` for each `PACKAGED_CORES` entry. Use the package key only when exactly one path is a file; otherwise raise the existing `UNRECOGNIZED_PLUGIN_ROOT` error.
+
+```text
+package_key = plugin_root.name
+if package_key not in PACKAGED_CORES:
+    matches = [key for key, core in PACKAGED_CORES.items()
+               if (plugin_root / "skills" / core / "SKILL.md").is_file()]
+    if len(matches) != 1:
+        fail(UNRECOGNIZED_PLUGIN_ROOT, existing message)
+    package_key = matches[0]
+```
+
+The established resource lookup then continues unchanged, using `package_key` to obtain the core name and required reference names.
+
+## Behavior and Error Handling
+
+- Recognized `ralph-specum` and `ralph-specum-codex` roots retain their current behavior, including later resource validation.
+- A versioned or otherwise arbitrary cache root succeeds only when exactly one known core `SKILL.md` is present.
+- Zero matches and multiple matches retain the exact `UNRECOGNIZED_PLUGIN_ROOT` failure; the resolver must not choose the first match or infer a parent cache directory.
+- No configuration, new dependency, or new public interface is introduced.
+
+## File Changes
+
+| File | Change |
+|---|---|
+| `plugins/ralph-specum/scripts/phase_gate.py` | Add the exact-one-core fallback. |
+| `plugins/ralph-specum-codex/scripts/phase_gate.py` | Apply the byte-identical mirror change. |
+| `tests/phase-gates.bats` | Add a real `record-skill-load` fixture rooted under an arbitrary version directory. |
+| Plugin manifests and Claude marketplace entry | Bump `4.12.0` to `4.12.1`. |
+| `tests/interview-framework.bats`, `tests/codex-phase-flow.bats` | Update fixed version assertions to `4.12.1`. |
+
+`.agents/plugins/marketplace.json` is unchanged because its local Codex-plugin entry has no version field.
+
+## Regression Strategy
+
+Build the fixture inside the existing Bats temporary directory: copy the Codex helper, `interview-framework-codex/SKILL.md`, and its two required references into a `.../4.11.0/` root. Generate a matching manifest and discovery entry against that copied helper, then run its real `record-skill-load` command.
+
+Assert all three cases:
+
+1. Only the Codex core exists: success and the copied core/reference paths validate.
+2. No known core exists: `UNRECOGNIZED_PLUGIN_ROOT`.
+3. Both known cores exist: `UNRECOGNIZED_PLUGIN_ROOT`.
+
+Keep the existing `cmp` assertion as the parity check for both production helpers.
+
+## Verification
+
+1. Run the new regression red against the pre-fix helper, then green after the resolver change.
+2. Run `python3 -m py_compile` on both helpers and `cmp` them.
+3. Run `bats tests/phase-gates.bats` locally when available; CI continues to run `bats tests/*.bats`.
+4. Run the version-sync/fixed-version tests and `git diff --check`.
+
+## Risks
+
+The only behavioral risk is accepting an ambiguous package. Exact match-count enforcement and the zero/multiple regression cases prevent it.

--- a/specs/fix-versioned-plugin-cache-phase-gate/prototypes/quick-cache-root-skip.md
+++ b/specs/fix-versioned-plugin-cache-phase-gate/prototypes/quick-cache-root-skip.md
@@ -1,0 +1,70 @@
+---
+spec: "fix-versioned-plugin-cache-phase-gate"
+phase: "prototype"
+id: "quick-cache-root-skip"
+status: "terminal"
+verdict: "skipped"
+kind: "logic"
+captureMode: "retained"
+triggerMode: "quick"
+triggerPhase: "requirements"
+returnPhase: "design"
+returnTaskIndex: null
+decisionOwner: "agent"
+resolutionMode: "no_suitable_question"
+gateApproved: false
+created: "2026-08-31T10:15:23Z"
+completed: "2026-08-31T10:15:23Z"
+sourceDisposition: "not_created"
+evidenceHash: null
+cleanupReceiptHash: null
+staleArtifacts: []
+staleTaskIndexes: []
+isolationBranch: null
+isolationPath: null
+sourcePointers: null
+---
+
+## Question
+
+Is a separate prototype needed before implementing the deterministic versioned-cache resolver fix?
+
+## Blocking Declaration
+
+none
+
+## Isolation
+
+none; no source was created
+
+## Run Instructions
+
+none
+
+## Cases Or Variants
+
+The research reproduction already exercises one recognized Codex core, zero cores, and multiple cores through the real phase-gate path.
+
+## Evidence And Observations
+
+The bug has a compact deterministic reproduction and bounded acceptance criteria; the production regression test is the smallest runnable validation.
+
+## Verdict
+
+skipped: no independent prototype would reduce implementation risk beyond the required regression test.
+
+## Downstream Handoff
+
+Exclude prototype evidence; proceed to design with the research and requirements artifacts.
+
+## Conflict Resolution
+
+none
+
+## Staleness
+
+none
+
+## Source Disposition
+
+not created because a throwaway experiment would duplicate the planned regression test.

--- a/specs/fix-versioned-plugin-cache-phase-gate/prototypes/quick-cache-root-skip.md
+++ b/specs/fix-versioned-plugin-cache-phase-gate/prototypes/quick-cache-root-skip.md
@@ -43,7 +43,7 @@ none
 
 ## Cases Or Variants
 
-The research reproduction already exercises one recognized Codex core, zero cores, and multiple cores through the real phase-gate path.
+The research reproduction exercises the one-core versioned-cache layout; the regression test covers zero- and multiple-core layouts.
 
 ## Evidence And Observations
 

--- a/specs/fix-versioned-plugin-cache-phase-gate/requirements.md
+++ b/specs/fix-versioned-plugin-cache-phase-gate/requirements.md
@@ -1,0 +1,81 @@
+---
+spec: fix-versioned-plugin-cache-phase-gate
+phase: requirements
+created: 2026-08-31
+---
+
+# Requirements: Versioned Plugin-Cache Phase Gate
+
+## Problem Statement
+
+`phase_gate.py` rejects a valid Codex plugin installed beneath a version directory because it identifies the package from the immediate directory name. The deterministic reproduction and root cause are documented in [research.md](research.md).
+
+## Goal
+
+Allow the shared phase-gate helper to identify exactly one packaged core interview skill from a versioned cache root, while retaining current behavior for recognized roots and malformed layouts.
+
+## User Story
+
+### US-1: Load a versioned Codex package
+
+**As a** Codex plugin user
+**I want** `record-skill-load` to work from an installed versioned plugin-cache directory
+**So that** Ralph Specum phases can start and load their required core resources.
+
+**Acceptance Criteria:**
+
+- Given a copied Codex package rooted at an arbitrary version directory with only `skills/interview-framework-codex/SKILL.md` and its required references, when `record-skill-load` runs, then it succeeds and resolves those exact files.
+- Given a package rooted directly at `ralph-specum` or `ralph-specum-codex`, when `record-skill-load` runs, then its existing core-resolution behavior remains valid.
+- Given an unknown root with zero known core skill files, or with both known core skill files, when `record-skill-load` runs, then it fails with `UNRECOGNIZED_PLUGIN_ROOT`.
+
+## Functional Requirements
+
+| ID | Requirement | Priority | Acceptance Criteria |
+|----|-------------|----------|---------------------|
+| FR-1 | `packaged_core_contract()` MUST retain its direct lookup for recognized package-root names. For another root name, it MUST inspect each known packaged core at `skills/<core>/SKILL.md` and use its package key only when exactly one exists. | Must | US-1 direct-root and versioned-root criteria |
+| FR-2 | The fallback MUST keep the existing `UNRECOGNIZED_PLUGIN_ROOT` failure when zero or more than one known core matches. It MUST not choose the first match or infer a cache-parent name. | Must | US-1 malformed-layout criterion |
+| FR-3 | The same resolver change MUST be applied byte-for-byte to `plugins/ralph-specum/scripts/phase_gate.py` and `plugins/ralph-specum-codex/scripts/phase_gate.py`; the existing parity check must remain green. | Must | Helper comparison test passes |
+| FR-4 | A focused regression in `tests/phase-gates.bats` MUST exercise the real `record-skill-load` path from a versioned Codex cache fixture, including one-core success and zero-/multiple-core rejection. | Must | The test is red before the resolver change and green after it |
+| FR-5 | Release metadata MUST move from `4.12.0` to `4.12.1` in `plugins/ralph-specum/.claude-plugin/plugin.json`, `plugins/ralph-specum-codex/.codex-plugin/plugin.json`, and the `ralph-specum` entry in `.claude-plugin/marketplace.json`. Fixed expectations in `tests/interview-framework.bats` and `tests/codex-phase-flow.bats` MUST also become `4.12.1`. | Must | Version-sync and fixed-version assertions pass |
+
+## Non-Functional Requirements
+
+| ID | Requirement | Metric | Target |
+|----|-------------|--------|--------|
+| NFR-1 | Resolution is deterministic. | Matching package cores | Exactly one match succeeds; zero or multiple fail. |
+| NFR-2 | The fix has no new runtime dependency or configuration. | Added dependencies/configuration | 0 |
+| NFR-3 | Existing package layouts remain compatible. | Direct-root regression | Both recognized package roots retain their current mapping. |
+
+## Glossary
+
+- **Recognized package root**: A root directory named `ralph-specum` or `ralph-specum-codex`.
+- **Versioned cache root**: The arbitrary version-directory root from which an installed plugin helper executes.
+- **Known core**: A `PACKAGED_CORES` entry whose packaged `skills/<core>/SKILL.md` is present.
+
+## Out of Scope
+
+- Changing phase interview, discovery, manifest, or resource-validation semantics beyond package-root identification.
+- Adding cache-layout configuration, plugin dependencies, or support for unknown core skill names.
+- Updating `.agents/plugins/marketplace.json`, which has no version field for its local Codex plugin source.
+
+## Dependencies
+
+- Python standard library (`pathlib.Path`) and existing `PACKAGED_CORES` / `PACKAGED_CORE_RESOURCES` constants.
+- Bats coverage in CI; the local environment may not provide the `bats` executable.
+
+## Success Criteria
+
+- The versioned-cache reproduction from [research.md](research.md) succeeds with the correct Codex core and reference paths.
+- Zero- and multiple-core fixtures still produce `UNRECOGNIZED_PLUGIN_ROOT`.
+- Both helper copies compare equal, the targeted Bats regression passes where Bats is available, and the release metadata is synchronized at `4.12.1`.
+
+## Risks
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| An ambiguous cache layout silently selects a core. | Medium | Require an exact count of one and test zero/multiple matches. |
+| Plugin copies or release versions drift. | Low | Retain parity and version-sync assertions. |
+
+## Unresolved Questions
+
+- None.

--- a/specs/fix-versioned-plugin-cache-phase-gate/research.md
+++ b/specs/fix-versioned-plugin-cache-phase-gate/research.md
@@ -1,0 +1,108 @@
+---
+spec: fix-versioned-plugin-cache-phase-gate
+phase: research
+created: 2026-08-31
+---
+
+# Research: fix-versioned-plugin-cache-phase-gate
+
+## Executive Summary
+
+Issue #147 is reproducible: `record-skill-load` rejects a valid Codex package when its immediate package directory is a version (for example, `4.11.0`) rather than `ralph-specum-codex`. The smallest safe repair is a content-based fallback in `packaged_core_contract()`: for an unknown directory name, accept exactly one known core whose `skills/<core>/SKILL.md` exists; retain `UNRECOGNIZED_PLUGIN_ROOT` for zero or multiple matches.
+
+Both shipped helpers are byte-identical, so update both with the same bytes and keep the existing equality test. This is a patch-level plugin fix with no new dependency or abstraction.
+
+## External Research
+
+### Best Practices
+
+- The primary issue explicitly specifies content-based discovery, exactly-one-match acceptance, and preserved zero/multiple-match errors: [Issue #147](https://github.com/tzachbon/smart-ralph/issues/147).
+- Use the existing `PACKAGED_CORES`, `PACKAGED_CORE_RESOURCES`, `Path`, and `PhaseGateError`; no dependency is needed.
+
+### Prior Art
+
+- Existing recognized-root behavior maps package keys through `PACKAGED_CORES` and then derives `SKILL.md`, `algorithm.md`, and `domain-modeling.md` from that root.
+
+### Pitfalls to Avoid
+
+- Do not select the first discovered core: ambiguity must continue to fail.
+- Do not infer a cache parent directory; the installed version directory is intentionally arbitrary.
+- Do not alter behavior for a recognized package key, including its current later file-validation behavior.
+
+## Codebase Analysis
+
+### Existing Patterns
+
+- `packaged_core_contract()` uses `Path(__file__).resolve().parent.parent` and immediately looks up `plugin_root.name` in `PACKAGED_CORES` at `plugins/ralph-specum-codex/scripts/phase_gate.py:296` (identical in `plugins/ralph-specum/scripts/phase_gate.py:296`).
+- `validate_skill_load()` calls this resolver before accepting a core receipt; `record-skill-load`, stale-load validation, and artifact-load validation all flow through it (`plugins/ralph-specum-codex/scripts/phase_gate.py:332`, `:676`, `:716`, `:934`). Fixing the shared resolver covers every caller.
+- The copies have the same SHA-256 (`a45af8e033d7bca651219961f170435e423da324b17c8328353ba5fe708a947f`) and `tests/phase-gates.bats:202` already asserts `cmp` equality.
+
+### Reproduction
+
+Executed a valid start-phase `record-skill-load` fixture from this temporary package layout (the helper and the Codex core skill plus both references were copied from the repository):
+
+```text
+<tmp>/cache/smart-ralph/ralph-specum-codex/4.11.0/
+  scripts/phase_gate.py
+  skills/interview-framework-codex/SKILL.md
+  skills/interview-framework-codex/references/{algorithm.md,domain-modeling.md}
+
+python3 <tmp>/cache/smart-ralph/ralph-specum-codex/4.11.0/scripts/phase_gate.py \
+  record-skill-load <tmp>/state.json --input <tmp>/manifest.json
+```
+
+```text
+ERROR: UNRECOGNIZED_PLUGIN_ROOT: phase gate helper is outside a recognized packaged plugin root
+```
+
+The manifest has matching hashes, discovery, and context digest; the only differing condition is the valid versioned immediate directory. This is a deterministic, red-capable reproduction of the reported command failure.
+
+### Dependencies
+
+- Python standard library only (`pathlib.Path.is_file()` is sufficient).
+- Bats test coverage already exists in `tests/phase-gates.bats`; the local image lacks `bats` (`bats: command not found`). CI installs it and runs `bats tests/*.bats` in `.github/workflows/bats-tests.yml:37`.
+
+### Constraints
+
+- The fallback must inspect only `plugin_root / "skills" / core_name / "SKILL.md"` for each key in `PACKAGED_CORES`; use the key only when the match count is exactly one.
+- Keep the existing `UNRECOGNIZED_PLUGIN_ROOT` error for zero and multiple matches.
+- The repository rules require a patch version bump for each modified plugin. Current manifests are `4.12.0`; bump to `4.12.1` in both plugin manifests and the Claude marketplace entry. Update the two hard-coded version assertions in `tests/interview-framework.bats:155` and `tests/codex-phase-flow.bats:19-23`.
+- `tests/helpers/version-sync.sh:3-9` requires the Claude and Codex plugin manifests to match; `.github/workflows/codex-version-check.yml:18-100` also checks a Codex package change has a version bump.
+
+## Related Specs
+
+| Spec | Relevance | Relationship | May Need Update |
+|------|-----------|--------------|-----------------|
+| None identified | Low | Isolated package-root resolution fix | No |
+
+### Coordination Notes
+
+No cross-spec coordination is needed. The two plugin distributions must remain synchronized.
+
+## Feasibility Assessment
+
+| Aspect | Assessment | Notes |
+|--------|------------|-------|
+| Technical Viability | High | A small fallback in the shared resolver fixes every gate caller. |
+| Effort Estimate | S | Two identical helper edits, one focused regression test, and required version updates. |
+| Risk Level | Low | Exact-match selection preserves rejection of malformed and ambiguous layouts. |
+
+## Recommendations for Requirements
+
+1. In both `phase_gate.py` copies, retain direct lookup for known roots; otherwise collect `PACKAGED_CORES` keys whose packaged core `SKILL.md` exists, require exactly one, and use that key for the existing resource lookup.
+2. Add a focused `tests/phase-gates.bats` regression covering a versioned Codex layout with one core (success and exact returned skill/reference paths), no cores (same error), and both cores (same error). The existing byte-equality test covers the mirrored helper after both files are updated identically.
+3. Bump `4.12.0` to `4.12.1` in `plugins/ralph-specum/.claude-plugin/plugin.json`, `plugins/ralph-specum-codex/.codex-plugin/plugin.json`, and `.claude-plugin/marketplace.json`, then update the two fixed-version Bats assertions.
+
+## Open Questions
+
+- None. The issue defines the required fallback and ambiguity behavior.
+
+## Sources
+
+- [Issue #147: versioned plugin-cache failure and required behavior](https://github.com/tzachbon/smart-ralph/issues/147)
+- `plugins/ralph-specum-codex/scripts/phase_gate.py:52-59,296-307,332-456,676-740,934-1021`
+- `plugins/ralph-specum/scripts/phase_gate.py:52-59,296-307` (byte-identical mirror)
+- `tests/phase-gates.bats:1-220,928-1030`
+- `.github/workflows/bats-tests.yml:37-43`
+- `tests/helpers/version-sync.sh:3-9`, `.github/workflows/codex-version-check.yml:18-100`
+- `plugins/ralph-specum/.claude-plugin/plugin.json`, `plugins/ralph-specum-codex/.codex-plugin/plugin.json`, `.claude-plugin/marketplace.json`

--- a/specs/fix-versioned-plugin-cache-phase-gate/tasks.md
+++ b/specs/fix-versioned-plugin-cache-phase-gate/tasks.md
@@ -1,0 +1,102 @@
+# Tasks: Fix Versioned Plugin-Cache Phase Gate
+
+## Overview
+
+Total tasks: 5
+
+Intent: focused bug fix using a TDD red-green cycle. The skipped quick prototype is sufficient evidence; no separate prototype, dependency, refactor, push, or PR work is needed.
+
+## Completion Criteria
+
+- A versioned Codex cache root with exactly one known core completes the real `record-skill-load` path.
+- Zero and multiple known-core layouts still return `UNRECOGNIZED_PLUGIN_ROOT`.
+- Both shipped helpers remain byte-identical and release metadata is synchronized at `4.12.1`.
+- Local verification is complete; quick mode skips the remote lifecycle.
+
+## Phase 1: Red-Green-Yellow Cycles
+
+- [x] 1.1 [RED] Add the versioned Codex cache regression fixture
+  - **Do**:
+    1. Add one focused Bats test to `tests/phase-gates.bats` that copies the Codex helper, `interview-framework-codex/SKILL.md`, and its two required references beneath an arbitrary `4.11.0` cache-root directory.
+    2. Build matching discovery and skill-load JSON for that copied package and invoke its real `record-skill-load` command.
+    3. Assert one known core is expected to succeed, while zero known cores and both known cores must return `UNRECOGNIZED_PLUGIN_ROOT`.
+  - **Files**: `tests/phase-gates.bats`
+  - **Done when**: Before the resolver fix, the one-core assertion fails specifically with `UNRECOGNIZED_PLUGIN_ROOT`; the zero- and multiple-core assertions already prove the preserved rejection behavior.
+  - **Verify**: `command -v bats >/dev/null && bash -c 'bats tests/phase-gates.bats --filter "versioned Codex cache root"; test $? -ne 0'`
+  - **Commit**: `test(phase-gate): red - cover versioned Codex cache roots`
+  - _Requirements: FR-1, FR-2, FR-4_
+  - _Design: Regression Strategy_
+
+- [x] 1.2 [GREEN] Resolve exactly one packaged core from an unknown root
+  - **Do**:
+    1. Keep the recognized-root lookup in `packaged_core_contract()` unchanged.
+    2. For an unrecognized root only, collect `PACKAGED_CORES` entries whose `skills/<core>/SKILL.md` exists and accept the package key only when the count is exactly one.
+    3. Preserve the existing `UNRECOGNIZED_PLUGIN_ROOT` error for zero or multiple matches, then apply the same bytes to the mirrored helper.
+  - **Files**: `plugins/ralph-specum/scripts/phase_gate.py`, `plugins/ralph-specum-codex/scripts/phase_gate.py`
+  - **Done when**: The red fixture passes, direct package roots retain their current mapping, and both helper files compare equal.
+  - **Verify**: `command -v bats >/dev/null && bats tests/phase-gates.bats --filter "versioned Codex cache root" && cmp plugins/ralph-specum/scripts/phase_gate.py plugins/ralph-specum-codex/scripts/phase_gate.py`
+  - **Commit**: `fix(phase-gate): support versioned plugin cache roots`
+  - _Requirements: FR-1, FR-2, FR-3_
+  - _Design: Approach; Behavior and Error Handling_
+
+## Phase 2: Release Compatibility
+
+- [x] 2.1 Bump the two plugin manifests and Claude marketplace entry
+  - **Do**:
+    1. Change the Ralph Specum version from `4.12.0` to `4.12.1` in both modified plugin manifests.
+    2. Change only the `ralph-specum` entry in the Claude marketplace to `4.12.1`.
+  - **Files**: `plugins/ralph-specum/.claude-plugin/plugin.json`, `plugins/ralph-specum-codex/.codex-plugin/plugin.json`, `.claude-plugin/marketplace.json`
+  - **Done when**: Both manifests and the marketplace entry report exactly `4.12.1`; no unrelated marketplace entry changes.
+  - **Verify**: `bash tests/helpers/version-sync.sh && jq -e '.plugins[] | select(.name == "ralph-specum") | .version == "4.12.1"' .claude-plugin/marketplace.json`
+  - **Commit**: `chore(ralph-specum): bump plugin version to 4.12.1`
+  - _Requirements: FR-5_
+
+- [x] 2.2 Update fixed version expectations
+  - **Do**:
+    1. Update the Ralph Specum marketplace-version assertion to `4.12.1`.
+    2. Update the Codex phase-flow manifest-version assertion to `4.12.1`.
+  - **Files**: `tests/interview-framework.bats`, `tests/codex-phase-flow.bats`
+  - **Done when**: Both fixed assertions agree with the released manifest version and still test their original contracts.
+  - **Verify**: `rg -n '4\.12\.1' tests/interview-framework.bats tests/codex-phase-flow.bats`
+  - **Commit**: `test(ralph-specum): align fixed version assertions`
+  - _Requirements: FR-5_
+
+## Phase 3: Final Local Quality Gate
+
+- [x] VF [VERIFY] Validate the cache fix, release synchronization, and diff
+  - **Do**:
+    1. Compile both helpers from their source bytes without creating cache files.
+    2. Run the Bats fixture's manual copied-cache reproduction: the one-core `record-skill-load` invocation must return `0` and its selected core/reference paths must be inside the temporary `4.11.0` root; the zero- and both-core variants must return `2` with `UNRECOGNIZED_PLUGIN_ROOT`.
+    3. Run parity, version, Bats-when-available, and whitespace checks; do not push, open a PR, or perform remote lifecycle work.
+  - **Files**: None
+  - **Done when**: Python compilation succeeds, the manual cache reproduction has the required three outcomes, helpers are byte-identical, versions are `4.12.1`, applicable Bats tests pass, and `git diff --check` is clean.
+  - **Verify**:
+    ```bash
+    python3 - <<'PY'
+    from pathlib import Path
+    for source in (
+        "plugins/ralph-specum/scripts/phase_gate.py",
+        "plugins/ralph-specum-codex/scripts/phase_gate.py",
+    ):
+        compile(Path(source).read_text(encoding="utf-8"), source, "exec")
+    PY
+    # Run the fixture's three copied-cache record-skill-load commands.
+    cmp plugins/ralph-specum/scripts/phase_gate.py plugins/ralph-specum-codex/scripts/phase_gate.py
+    bash tests/helpers/version-sync.sh
+    jq -e '.plugins[] | select(.name == "ralph-specum") | .version == "4.12.1"' .claude-plugin/marketplace.json
+    if command -v bats >/dev/null; then bats tests/phase-gates.bats tests/interview-framework.bats tests/codex-phase-flow.bats; else echo 'Bats unavailable locally; CI runs the Bats suite'; fi
+    git diff --check
+    ```
+  - **Commit**: None
+  - _Requirements: FR-1, FR-2, FR-3, FR-4, FR-5; NFR-1, NFR-2, NFR-3_
+
+## Dependencies
+
+```text
+1.1 [RED] -> 1.2 [GREEN] -> 2.1 -> 2.2 -> VF [VERIFY]
+```
+
+## Notes
+
+- No yellow refactor task is needed: the resolver fallback is the complete minimal implementation and the mirror parity test guards against drift.
+- Remote lifecycle skipped: prototype evidence stayed local.

--- a/tests/codex-phase-flow.bats
+++ b/tests/codex-phase-flow.bats
@@ -16,11 +16,11 @@ ralph-specum-tasks
 EOF
 }
 
-@test "codex phase flow: manifest is 4.12.1 and core interview skill is internal" {
+@test "codex phase flow: manifest is 4.12.2 and core interview skill is internal" {
     local root
     root="$(plugin_root)"
 
-    run python3 -c "import json; assert json.load(open('$root/.codex-plugin/plugin.json'))['version'] == '4.12.1'"
+    run python3 -c "import json; assert json.load(open('$root/.codex-plugin/plugin.json'))['version'] == '4.12.2'"
     [ "$status" -eq 0 ]
     [ -f "$root/skills/interview-framework-codex/SKILL.md" ]
     [ -f "$root/skills/interview-framework-codex/references/algorithm.md" ]

--- a/tests/codex-phase-flow.bats
+++ b/tests/codex-phase-flow.bats
@@ -16,11 +16,11 @@ ralph-specum-tasks
 EOF
 }
 
-@test "codex phase flow: manifest is 4.12.0 and core interview skill is internal" {
+@test "codex phase flow: manifest is 4.12.1 and core interview skill is internal" {
     local root
     root="$(plugin_root)"
 
-    run python3 -c "import json; assert json.load(open('$root/.codex-plugin/plugin.json'))['version'] == '4.12.0'"
+    run python3 -c "import json; assert json.load(open('$root/.codex-plugin/plugin.json'))['version'] == '4.12.1'"
     [ "$status" -eq 0 ]
     [ -f "$root/skills/interview-framework-codex/SKILL.md" ]
     [ -f "$root/skills/interview-framework-codex/references/algorithm.md" ]

--- a/tests/interview-framework.bats
+++ b/tests/interview-framework.bats
@@ -152,5 +152,5 @@ PHASE_COMMANDS=(
 
     [[ "$plugin_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
     [ "$plugin_version" = "$marketplace_version" ]
-    [ "$plugin_version" = "4.12.1" ]
+    [ "$plugin_version" = "4.12.2" ]
 }

--- a/tests/interview-framework.bats
+++ b/tests/interview-framework.bats
@@ -152,5 +152,5 @@ PHASE_COMMANDS=(
 
     [[ "$plugin_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
     [ "$plugin_version" = "$marketplace_version" ]
-    [ "$plugin_version" = "4.12.0" ]
+    [ "$plugin_version" = "4.12.1" ]
 }

--- a/tests/phase-gates.bats
+++ b/tests/phase-gates.bats
@@ -74,8 +74,8 @@ write_skill_load() {
     warnings="${3:-[]}"
     resource_errors="${4:-[]}"
     failures="${5:-[]}"
-    plugin_root="$(dirname "$(dirname "$helper")")"
-    plugin_name="$(basename "$plugin_root")"
+    plugin_root="${PHASE_GATE_TEST_PLUGIN_ROOT:-$(dirname "$(dirname "$helper")")}"
+    plugin_name="${PHASE_GATE_TEST_PLUGIN_NAME:-$(basename "$plugin_root")}"
     if [ "$plugin_name" = "ralph-specum-codex" ]; then
         core_name="interview-framework-codex"
     else
@@ -213,6 +213,70 @@ record_complete_gate() {
     [[ "$output" == *"check-agent-write"* ]]
     [[ "$output" == *"check-delegation"* ]]
     [[ "$output" == *"is-substantive"* ]]
+}
+
+@test "versioned Codex cache roots require exactly one packaged core" {
+    local source_root state_template cache_root zero_root both_root
+    local one_state zero_state both_state one_input zero_input both_input
+    source_root="$(repo_root)/plugins/ralph-specum-codex"
+    state_template="$STATE_FILE"
+    cache_root="$TEST_DIR/cache/smart-ralph/ralph-specum-codex/4.11.0"
+    zero_root="$TEST_DIR/zero-cache/smart-ralph/ralph-specum-codex/4.11.0"
+    both_root="$TEST_DIR/both-cache/smart-ralph/ralph-specum-codex/4.11.0"
+
+    mkdir -p "$cache_root/scripts" "$cache_root/skills/interview-framework-codex/references"
+    cp "$source_root/scripts/phase_gate.py" "$cache_root/scripts/phase_gate.py"
+    cp "$source_root/skills/interview-framework-codex/SKILL.md" \
+        "$cache_root/skills/interview-framework-codex/SKILL.md"
+    cp "$source_root/skills/interview-framework-codex/references/algorithm.md" \
+        "$cache_root/skills/interview-framework-codex/references/algorithm.md"
+    cp "$source_root/skills/interview-framework-codex/references/domain-modeling.md" \
+        "$cache_root/skills/interview-framework-codex/references/domain-modeling.md"
+
+    one_state="$TEST_DIR/one-cache-state.json"
+    one_input="$TEST_DIR/one-cache-skill-load.json"
+    cp "$state_template" "$one_state"
+    STATE_FILE="$one_state"
+    helper="$cache_root/scripts/phase_gate.py"
+    PHASE_GATE_TEST_PLUGIN_ROOT="$cache_root" \
+        PHASE_GATE_TEST_PLUGIN_NAME="ralph-specum-codex" write_skill_load
+    mv "$TEST_DIR/skill-load.json" "$one_input"
+
+    mkdir -p "$zero_root/scripts"
+    cp "$cache_root/scripts/phase_gate.py" "$zero_root/scripts/phase_gate.py"
+    zero_state="$TEST_DIR/zero-cache-state.json"
+    zero_input="$TEST_DIR/zero-cache-skill-load.json"
+    cp "$state_template" "$zero_state"
+    STATE_FILE="$zero_state"
+    helper="$zero_root/scripts/phase_gate.py"
+    PHASE_GATE_TEST_PLUGIN_ROOT="$cache_root" \
+        PHASE_GATE_TEST_PLUGIN_NAME="ralph-specum-codex" write_skill_load
+    mv "$TEST_DIR/skill-load.json" "$zero_input"
+
+    mkdir -p "$both_root"
+    cp -R "$cache_root/." "$both_root"
+    mkdir -p "$both_root/skills/interview-framework"
+    cp "$source_root/skills/interview-framework-codex/SKILL.md" \
+        "$both_root/skills/interview-framework/SKILL.md"
+    both_state="$TEST_DIR/both-cache-state.json"
+    both_input="$TEST_DIR/both-cache-skill-load.json"
+    cp "$state_template" "$both_state"
+    STATE_FILE="$both_state"
+    helper="$both_root/scripts/phase_gate.py"
+    PHASE_GATE_TEST_PLUGIN_ROOT="$both_root" \
+        PHASE_GATE_TEST_PLUGIN_NAME="ralph-specum-codex" write_skill_load
+    mv "$TEST_DIR/skill-load.json" "$both_input"
+
+    run python3 "$zero_root/scripts/phase_gate.py" record-skill-load "$zero_state" --input "$zero_input"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"UNRECOGNIZED_PLUGIN_ROOT"* ]]
+
+    run python3 "$both_root/scripts/phase_gate.py" record-skill-load "$both_state" --input "$both_input"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"UNRECOGNIZED_PLUGIN_ROOT"* ]]
+
+    run python3 "$cache_root/scripts/phase_gate.py" record-skill-load "$one_state" --input "$one_input"
+    [ "$status" -eq 0 ]
 }
 
 @test "schemas expose matching required phase gate state" {


### PR DESCRIPTION
Fixes #147.

## Summary
- resolve packaged core by the installed skill directory when the plugin root is a versioned Codex cache directory
- preserve the existing failure for zero or ambiguous known packaged cores
- add copied-cache coverage and bump Ralph Specum to 4.12.2

## Verification
- manual versioned-cache matrix: one core succeeds; zero/multiple cores fail
- Python compilation, mirrored helper parity, version-sync, and diff checks
- Bats is unavailable in this environment